### PR TITLE
Fix undefined constant error

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -3,7 +3,7 @@ module Hutch
   require 'hutch/worker'
   require 'hutch/logging'
   require 'hutch/error_handlers/logger'
-  require 'hutch/error_handlers/sentry' if defined?(Raven)
+  ErrorHandlers.autoload :Sentry, 'hutch/error_handlers/sentry'
 
   def self.register_consumer(consumer)
     self.consumers << consumer


### PR DESCRIPTION
Circle CI surfaced a tricky case where Hutch was required before Raven, consequently not requiring the `hutch/error_handlers/sentry` file. But at runtime when Raven namespace **was** defined, it tried to use `Hutch::ErrorHandlers::Sentry`, but the file for that hadn't been required.

So to mitigate that, me and Alan (mostly Alan) came up with this autoload thing.

@hmarr your thoughts please?
