### PR TITLE
mq-api-host config defaults to mq-host if not set

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -109,7 +109,7 @@ module Hutch
         end
 
         opts.on('--mq-api-host HOST', 'Set the RabbitMQ API host') do |host|
-          Hutch::Config.mq_api_host = host
+          Hutch::Config.mq_api_host = host || Hutch::Config.mq_host
         end
 
         opts.on('--mq-api-port PORT', 'Set the RabbitMQ API port') do |port|


### PR DESCRIPTION
@alan @hmarr if you can review asap so we can update GoCardless and deploy again
