### PR TITLE
Allow Bunny 0.10.x versions

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/hutch/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'bunny', '0.10.6'
+  gem.add_runtime_dependency 'bunny', '~> 0.10.6'
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.5'
   gem.add_development_dependency 'rspec', '~> 2.12.0'


### PR DESCRIPTION
Versioned-pinned dependencies is not a good
idea most of the time.

All 0.10.x releases are backwards compatible (for realistic
scenarios, anyway). You can be assured we will do our best
to keep things the same way for `1.0.x`.
