### PR TITLE
Ignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle
 hutch-*.gem
+Gemfile.lock


### PR DESCRIPTION
Gemfile.lock turns out to be neither committed, nor ignored.
Committing it is a good idea for apps but ignoring is more suitable
for libraries.
