### PR TITLE
Update README.md: Connect to RabbitMQ before publishing messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ possible, this should be used, rather than directly interfacing with RabbitMQ
 libraries.
 
 ```ruby
+Hutch.connect
 Hutch.publish('routing.key', subject: 'payment', action: 'received')
 ```
 


### PR DESCRIPTION
Just to make first-time users happy.
