### PR TITLE
fixed missing mq_tls config option

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -10,7 +10,6 @@ module Hutch
         mq_port: 5672,
         mq_exchange: 'hutch',  # TODO: should this be required?
         mq_vhost: '/',
-        mq_ssl: false,
         mq_tls: false,
         mq_username: 'guest',
         mq_password: 'guest',


### PR DESCRIPTION
rabbitmq-3.0.4 seems to set up this mq_tls option which was not seen as a valid key. Now is. :D
