### PR TITLE
Add code climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ in a service-oriented architecture, using RabbitMQ.
 [![Gem Version](https://badge.fury.io/rb/hutch.png)](http://badge.fury.io/rb/hutch)
 [![Build Status](https://travis-ci.org/gocardless/hutch.png?branch=master)](https://travis-ci.org/gocardless/hutch)
 [![Dependency Status](https://gemnasium.com/gocardless/hutch.png)](https://gemnasium.com/gocardless/hutch)
+[![Code Climate](https://codeclimate.com/github/gocardless/hutch.png)](https://codeclimate.com/github/gocardless/hutch)
 
 To install with RubyGems:
 


### PR DESCRIPTION
[Code Climate](https://codeclimate.com/) provides an excellent hosted code
analysis tool which is free for open source projects.

This commit adds the badge for their service for the Hutch project, providing
visibility into such issues as duplication and method complexity as the
project evolves. I've found these analyses very useful in the past.
