### PR TITLE
Bunny 1.0.3+

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/hutch/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'bunny', '~> 1.0.0'
+  gem.add_runtime_dependency 'bunny', '~> 1.0.3'
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.5'
   gem.add_development_dependency 'rspec', '~> 2.12.0'


### PR DESCRIPTION
It's the same as [1.0.1](http://blog.rubyrabbitmq.info/blog/2013/11/06/bunny-1-dot-0-1-is-released/) but fixes a couple of release blunders (e.g. debug logging to stdout in the code).
