### PR TITLE
Set content_type property to 'application/json'

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -166,7 +166,9 @@ module Hutch
       end
 
       non_overridable_properties = {
-        routing_key: routing_key, timestamp: Time.now.to_i
+        routing_key: routing_key,
+        timestamp: Time.now.to_i,
+        content_type: 'application/json'
       }
       properties[:message_id] ||= generate_id
 

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -145,7 +145,20 @@ describe Hutch::Broker do
         broker.publish('test.key', 'message')
       end
 
-      it "allows passing message properties" do
+      it 'sets default properties' do
+        broker.exchange.should_receive(:publish).with(
+          JSON.dump("message"),
+          hash_including(
+            persistent: true,
+            routing_key: 'test.key',
+            content_type: 'application/json'
+          )
+        )
+
+        broker.publish('test.key', 'message')
+      end
+
+      it 'allows passing message properties' do
         broker.exchange.should_receive(:publish).once
         broker.publish('test.key', 'message', {expiration: "2000", persistent: false})
       end


### PR DESCRIPTION
Since we're always sending json data in the message, it would make sense to set the content_type property. Doing this could affect consumers using different amqp clients. For example, node-amqp will provide you with the `JSON.parsed` data instead of the raw message.

Closes #59.
