### PR TITLE
Pass all arguments down to Hutch::Broker#publish.

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -37,8 +37,8 @@ module Hutch
     @connected
   end
 
-  def self.publish(routing_key, message)
-    @broker.publish(routing_key, message)
+  def self.publish(*args)
+    broker.publish(*args)
   end
 end
 

--- a/spec/hutch_spec.rb
+++ b/spec/hutch_spec.rb
@@ -12,5 +12,19 @@ describe Hutch do
       Hutch.consumers.should include consumer_b
     end
   end
+
+  describe '#publish' do
+    let(:broker) { double(Hutch::Broker) }
+    let(:args) { ['test.key', 'message', { headers: { foo: 'bar' } }] }
+
+    before do
+      Hutch.stub broker: broker
+    end
+
+    it 'delegates to Hutch::Broker#publish' do
+      broker.should_receive(:publish).with(*args)
+      Hutch.publish(*args)
+    end
+  end
 end
 


### PR DESCRIPTION
Currently, it's not possible to pass properties via `Hutch.publish`. This change passes all arguments down to `Hutch::Broker#publish`.
