### PR TITLE
Merge in global properties.

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -21,6 +21,14 @@ module Hutch
     Hutch::Logging.logger
   end
 
+  def self.global_properties=(properties)
+    @global_properties = properties
+  end
+
+  def self.global_properties
+    @global_properties ||= {}
+  end
+
   def self.connect(config = Hutch::Config)
     unless connected?
       @broker = Hutch::Broker.new(config)

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -173,6 +173,7 @@ module Hutch
       logger.info("publishing message '#{message.inspect}' to #{routing_key}")
       @exchange.publish(payload, {persistent: true}.
         merge(properties).
+        merge(global_properties).
         merge(non_overridable_properties))
     end
 
@@ -184,6 +185,10 @@ module Hutch
 
     def generate_id
       SecureRandom.uuid
+    end
+
+    def global_properties
+      Hutch.global_properties.respond_to?(:call) ? Hutch.global_properties.call : Hutch.global_properties
     end
   end
 end

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -149,6 +149,30 @@ describe Hutch::Broker do
         broker.exchange.should_receive(:publish).once
         broker.publish('test.key', 'message', {expiration: "2000", persistent: false})
       end
+
+      context 'when there are global properties' do
+        context 'as a hash' do
+          before do
+            Hutch.stub global_properties: { app_id: 'app' }
+          end
+
+          it 'merges the properties' do
+            broker.exchange.should_receive(:publish).with('"message"', hash_including(app_id: 'app'))
+            broker.publish('test.key', 'message')
+          end
+        end
+
+        context 'as a callable object' do
+          before do
+            Hutch.stub global_properties: proc { { app_id: 'app' } }
+          end
+
+          it 'calls the proc and merges the properties' do
+            broker.exchange.should_receive(:publish).with('"message"', hash_including(app_id: 'app'))
+            broker.publish('test.key', 'message')
+          end
+        end
+      end
     end
 
     context 'without a valid connection' do


### PR DESCRIPTION
At remind101, we run most of our apps on heroku, and we like to propagate the [request_id throughout our system](https://github.com/remind101/request_id). This change allows you to set some default properties, so that you can do things like set headers at a global level:

``` ruby
Hutch.global_properties = proc {
  { app_id: 'api', headers: { request_id: RequestId.request_id } }
}
```
