### PR TITLE
Fix warning about no consumers

### DIFF
--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -97,8 +97,7 @@ module Hutch
 
     def consumers=(val)
       if val.empty?
-        logger.warn 'no consumer loaded, ensure there\'s' +
-                    'no configuration issue'
+        logger.warn "no consumer loaded, ensure there's no configuration issue"
       end
       @consumers = val
     end


### PR DESCRIPTION
Before:

> 2014-01-21T05:43:30Z 49914 WARN -- no consumer loaded, ensure there'sno configuration issue

After:

> 2014-01-21T05:52:09Z 51407 WARN -- no consumer loaded, ensure there's no configuration issue

I put it all on one line since it's still less than 80 characters long.
