### PR TITLE
Allow namespace to include any valid rabbitmq queue name

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -98,7 +98,7 @@ module Hutch
     # Create / get a durable queue and apply namespace if it exists.
     def queue(name)
       with_bunny_precondition_handler('queue') do
-        namespace = @config[:namespace].to_s.downcase.gsub(/\W|:/, "")
+        namespace = @config[:namespace].to_s.downcase.gsub(/[^-_:\.\w]/, "")
         name = name.prepend(namespace + ":") unless namespace.empty?
         channel.queue(name, durable: true)
       end

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -82,8 +82,8 @@ describe Hutch::Broker do
     before { broker.stub(:channel) { channel } }
 
     it 'applies a global namespace' do
-      config[:namespace] = 'service'
-      broker.channel.should_receive(:queue).with { |*args| args.first == 'service:test' }
+      config[:namespace] = 'mirror-all.service'
+      broker.channel.should_receive(:queue).with { |*args| args.first == 'mirror-all.service:test' }
       broker.queue('test')
     end
   end
@@ -108,7 +108,7 @@ describe Hutch::Broker do
   end
 
   describe '#bind_queue' do
-    
+
     around { |example| broker.connect { example.run } }
 
     let(:routing_keys) { %w( a b c ) }


### PR DESCRIPTION
Allow namespace to include any valid rabbitmq queue name.

Closes #77
