### PR TITLE
Add an explicit require for set

### DIFF
--- a/lib/hutch/consumer.rb
+++ b/lib/hutch/consumer.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Hutch
   # Include this module in a class to register it as a consumer. Consumers
   # gain a class method called `consume`, which should be used to register


### PR DESCRIPTION
Add an explicit require for [Set](http://www.ruby-doc.org/stdlib-2.1.0/libdoc/set/rdoc/Set.html). Without it, you end up with the following exception:

``` sh
$ hutch --config config.yml --require consumer.rb
2014-01-31T18:19:35Z 11627 INFO -- hutch booted with pid 11627
2014-01-31T18:19:35Z 11627 INFO -- requiring 'consumer.rb'
/Users/garrett/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/hutch-0.7.0/lib/hutch/consumer.rb:35:in `routing_keys': uninitialized constant Hutch::Consumer::ClassMethods::Set (NameError)
  from /Users/garrett/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/hutch-0.7.0/lib/hutch/consumer.rb:15:in `consume'
```
