### PR TITLE
broker: ensure disconnect on failing block

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -19,8 +19,11 @@ module Hutch
       set_up_api_connection if options.fetch(:enable_http_api_use, true)
 
       if block_given?
-        yield
-        disconnect
+        begin
+          yield
+        ensure
+          disconnect
+        end
       end
     end
 

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -32,6 +32,17 @@ describe Hutch::Broker do
       end
     end
 
+    context 'when given a block that fails' do
+      let(:exception) { Class.new(StandardError) }
+
+      it 'disconnects' do
+        expect(broker).to receive(:disconnect).once
+        expect do
+          broker.connect { fail exception }
+        end.to raise_error(exception)
+      end
+    end
+
     context "with options" do
       let(:options) { { enable_http_api_use: false } }
 


### PR DESCRIPTION
When Broker#connect is passed a block and that block raises an exception - the broker does not disconnect.
