### PR TITLE
Add pidfile support

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -27,6 +27,7 @@ module Hutch
         error_handlers: [Hutch::ErrorHandlers::Logger.new],
         namespace: nil,
         daemonise: false,
+        pidfile: nil,
         channel_prefetch: 0
       }.merge(params)
     end


### PR DESCRIPTION
Currently I am trying to implement capistrano 3.x integration with my [capistrano-hutch](https://github.com/sharshenov/capistrano-hutch) gem.
So I have found out that it would be handy to have a `--pidfile` argument to start/stop Hutch daemon in production.
