### PR TITLE
Add payload to error handlers

### DIFF
--- a/lib/hutch/error_handlers/logger.rb
+++ b/lib/hutch/error_handlers/logger.rb
@@ -5,7 +5,7 @@ module Hutch
     class Logger
       include Logging
 
-      def handle(message_id, consumer, ex)
+      def handle(message_id, payload, consumer, ex)
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "error in consumer '#{consumer}'"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -12,7 +12,7 @@ module Hutch
         end
       end
 
-      def handle(message_id, consumer, ex)
+      def handle(message_id, payload, consumer, ex)
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Sentry"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -85,13 +85,13 @@ module Hutch
         broker.ack(delivery_info.delivery_tag)
       rescue StandardError => ex
         broker.nack(delivery_info.delivery_tag)
-        handle_error(properties.message_id, consumer, ex)
+        handle_error(properties.message_id, payload, consumer, ex)
       end
     end
 
-    def handle_error(message_id, consumer, ex)
+    def handle_error(message_id, payload, consumer, ex)
       Hutch::Config[:error_handlers].each do |backend|
-        backend.handle(message_id, consumer, ex)
+        backend.handle(message_id, payload, consumer, ex)
       end
     end
 

--- a/spec/hutch/error_handlers/logger_spec.rb
+++ b/spec/hutch/error_handlers/logger_spec.rb
@@ -9,7 +9,7 @@ describe Hutch::ErrorHandlers::Logger do
 
     it "logs three separate lines" do
       expect(Hutch::Logging.logger).to receive(:error).exactly(3).times
-      error_handler.handle("1", double, error)
+      error_handler.handle("1", "{}", double, error)
     end
   end
 end

--- a/spec/hutch/error_handlers/sentry_spec.rb
+++ b/spec/hutch/error_handlers/sentry_spec.rb
@@ -14,7 +14,7 @@ describe Hutch::ErrorHandlers::Sentry do
 
     it "logs the error to Sentry" do
       expect(Raven).to receive(:capture_exception).with(error)
-      error_handler.handle("1", double, error)
+      error_handler.handle("1", "{}", double, error)
     end
   end
 end


### PR DESCRIPTION
I've got a custom honeybadger error handler that I am using here and it would be really useful to have the payload as a part of this information.

Open to this? Would you like it done differently?
