### PR TITLE
Enable Publisher Confirms

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ Hutch.connect
 Hutch.publish('routing.key', subject: 'payment', action: 'received')
 ```
 
+### Producer Configuration
+
+Producers are not run with the 'hutch' command. You can specify configuration
+options as follows:
+
+```ruby
+Hutch::Config.set(:mq_exchange, 'name')
+```
+
+### Publisher Confirms
+
+For maximum message reliability when producing messages, you will need to
+enable [Publisher Confirms](https://www.rabbitmq.com/confirms.html).
+
+```ruby
+Hutch::Config.set(:publisher_confirms, true)
+```
+
 ### Writing Well-Behaved Publishers
 
 You may need to send messages to Hutch from languages other than Ruby. This

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -31,7 +31,8 @@ module Hutch
         namespace: nil,
         daemonise: false,
         pidfile: nil,
-        channel_prefetch: 0
+        channel_prefetch: 0,
+        publisher_confirms: false
       }.merge(params)
     end
 


### PR DESCRIPTION
- Add new publisher_confirms config option.
- Add section to README.md on how to configure hutch as a producer, since
  it doesn't use the command line.
- Add section to README.md on how to use publisher confirms setting.

I've not added publisher_confirms to the command-line parameters, since
it's only for use by the producer.

Resolves https://github.com/gocardless/hutch/issues/115 and
https://github.com/gocardless/hutch/issues/21 (and possibly
https://github.com/gocardless/hutch/issues/22)

Regarding comment
https://github.com/gocardless/hutch/issues/21#issuecomment-23178422
There is no need to wrap the code in a timeout handler in Hutch,
since 'Bunny::ClientTimeout' is raised if the server goes away.
(I've tested this by performing a 'kill -STOP' of the RabbitMQ
server.)

The relevant piece of Bunny code that handles timeouts is channel.rb
[wait_on_confirms_continuations](https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/channel.rb#L1781)
