### PR TITLE
NameError, cli.rb missing the VERSION constant

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 
+require 'hutch/version'
 require 'hutch/logging'
 require 'hutch/exceptions'
 require 'hutch/config'


### PR DESCRIPTION
This avoids the `uninitialized constant Hutch::CLI::VERSION (NameError)` when running `hutch --version`.
