### PR TITLE
fix: connected? method to check actual broker connection state

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -35,15 +35,11 @@ module Hutch
     unless connected?
       @broker = Hutch::Broker.new(config)
       @broker.connect(options)
-      @connected = true
     end
   end
 
   def self.disconnect
-    if @broker
-      @broker.disconnect
-      @connected = false
-    end
+    @broker.disconnect if @broker
   end
 
   def self.broker
@@ -51,7 +47,9 @@ module Hutch
   end
 
   def self.connected?
-    @connected
+    return false unless broker
+    return false unless broker.connection
+    broker.connection.open?
   end
 
   def self.publish(*args)

--- a/spec/hutch_spec.rb
+++ b/spec/hutch_spec.rb
@@ -27,11 +27,6 @@ describe Hutch do
         action
       end
 
-      it 'sets @connect' do
-        action
-
-        expect(Hutch.connected?).to be_truthy
-      end
     end
 
     context 'connected' do
@@ -41,6 +36,39 @@ describe Hutch do
         expect(Hutch::Broker).not_to receive :new
         Hutch.connect
       end
+    end
+  end
+
+  describe '.connected?' do
+    subject(:connected?) { Hutch.connected? }
+
+    before { allow(Hutch).to receive(:broker).and_return(broker) }
+
+    context 'without a broker' do
+      let(:broker) { nil }
+
+      it { expect(connected?).to be_falsey }
+    end
+
+    context 'without a connection' do
+      let(:connection) { nil }
+      let(:broker) { double(:broker, connection: connection) }
+
+      it { expect(connected?).to be_falsey }
+    end
+
+    context 'with a closed connection' do
+      let(:connection) { double(:connection, open?: false) }
+      let(:broker) { double(:broker, connection: connection) }
+
+      it { expect(connected?).to be_falsey }
+    end
+
+    context 'with an opened connection' do
+      let(:connection) { double(:connection, open?: true) }
+      let(:broker) { double(:broker, connection: connection) }
+
+      it { expect(connected?).to be_truthy }
     end
   end
 


### PR DESCRIPTION
Calling `Hutch.connect` on a closed connection will not make the broker re-connect.

Before:

``` ruby
Hutch.connect
Hutch.publish('foo', 'bar')
puts Hutch.connected?

Hutch.broker.connection.close
puts Hutch.connected?

Hutch.connect
Hutch.publish('foo', 'bar')
```

Would result in the following stack trace:

``` ruby
> Hutch.connect
 => true
> Hutch.publish('foo', 'bar')
2014-12-18T19:23:43Z 12293 INFO -- publishing message '"bar"' to foo
 => #<Bunny::Exchange:...>
> Hutch.connected?
 => true
> Hutch.broker.connection.close
 => :closed
> Hutch.connected?
 => true
> Hutch.connect
 => nil
> Hutch.publish('foo', 'bar')
2014-12-18T19:23:43Z 12293 ERROR -- Unable to publish - connection is closed. Message: "bar", Routing key: foo.
Hutch::PublishError: Unable to publish - connection is closed. Message: "bar", Routing key: foo.
```

Now:

``` ruby
> Hutch.connect
 => nil
> Hutch.publish('foo', 'bar')
2014-12-18T19:24:05Z 12386 INFO -- publishing message '"bar"' to foo
 => #<Bunny::Exchange:...>
> Hutch.connected?
 => true
> Hutch.broker.connection.close
 => :closed
> Hutch.connected?
 => false
> Hutch.connect
 => nil
> Hutch.publish('foo', 'bar')
2014-12-18T19:24:06Z 12386 INFO -- publishing message '"bar"' to foo
```
