### PR TITLE
Serialize messages for logging using JSON

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -216,9 +216,9 @@ module Hutch
       }
       properties[:message_id] ||= generate_id
 
-      logger.info("publishing message '#{message.inspect}' to #{routing_key}")
-
-      response = @exchange.publish(JSON.dump(message), {persistent: true}.
+      json = JSON.dump(message)
+      logger.info("publishing message '#{json}' to #{routing_key}")
+      response = @exchange.publish(json, {persistent: true}.
         merge(properties).
         merge(global_properties).
         merge(non_overridable_properties))
@@ -242,7 +242,7 @@ module Hutch
     private
 
     def raise_publish_error(reason, routing_key, message)
-      msg = "Unable to publish - #{reason}. Message: #{message.inspect}, Routing key: #{routing_key}."
+      msg = "unable to publish - #{reason}. Message: #{JSON.dump(message)}, Routing key: #{routing_key}."
       logger.error(msg)
       raise PublishError, msg
     end


### PR DESCRIPTION
We ran into an issue where we had a lot of errors publishing messages to rabbit. We need to resend the failed messages and the content is available in the server logs, but it's in ruby's inspect format making it a huge pain to parse and resend. 

So what do you think about just logging the JSON we're sending out? It makes it much simpler to resend failed messages from logs, and you don't have to wonder about how things like dates were serialized.