### PR TITLE
Allow configuration of Bunny's read and write timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Known configuration parameters are:
  * `force_publisher_confirms`: enables publisher confirms, forces `Hutch::Broker#wait_for_confirms` for every publish. **This is the safest option which also offers the lowest throughput**.
  * `log_level`: log level used by the standard Ruby logger (default: `Logger::INFO`)
  * `mq_exchange`: exchange to use for publishing (default: `hutch`)
+ * `heartbeat`: RabbitMQ heartbeat delay (default: `30`)
+ * `connection_timeout`: Bunny's socket open timeout (default: `11`)
+ * `read_timeout`: Bunny's socket read timeout (default: `11`)
+ * `write_timemout`: Bunny's socket write timeout (default: `11`)
 
 
 ## Supported RabbitMQ Versions

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -77,8 +77,11 @@ module Hutch
       tls                = @config[:mq_tls]
       tls_key            = @config[:mq_tls_key]
       tls_cert           = @config[:mq_tls_cert]
-      connection_timeout = @config[:connection_timeout]
       heartbeat          = @config[:heartbeat]
+      connection_timeout = @config[:connection_timeout]
+      read_timeout       = @config[:read_timeout]
+      write_timeout      = @config[:write_timeout]
+
       protocol           = tls ? "amqps://" : "amqp://"
       sanitized_uri      = "#{protocol}#{username}@#{host}:#{port}/#{vhost.sub(/^\//, '')}"
       logger.info "connecting to rabbitmq (#{sanitized_uri})"
@@ -86,7 +89,10 @@ module Hutch
                               tls: tls, tls_key: tls_key, tls_cert: tls_cert,
                               username: username, password: password,
                               heartbeat: heartbeat, automatically_recover: true,
-                              network_recovery_interval: 1, connection_timeout: connection_timeout)
+                              network_recovery_interval: 1,
+                              connection_timeout: connection_timeout,
+                              read_timeout: read_timeout,
+                              write_timeout: write_timeout)
 
       with_bunny_connection_handler(sanitized_uri) do
         @connection.start

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -41,6 +41,8 @@ module Hutch
         force_publisher_confirms: false,
         # Heroku needs > 10. MK.
         connection_timeout: 11,
+        read_timeout: 11,
+        write_timeout: 11,
         enable_http_api_use: true
       }.merge(params)
     end


### PR DESCRIPTION
With the release of Bunny 1.7, the `read_timeout` and `write_timeout` are now up for configuration. This allows more fine grained control of timeout related error handling when reading and writing to RabbitMQ.

It is currently defaulted to `5` in Bunny and that is too low for some of our applications.