### PR TITLE
Support ERb in YAML config

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -78,7 +78,7 @@ module Hutch
     end
 
     def self.load_from_file(file)
-      YAML.load(file).each do |attr, value|
+      YAML.load(ERB.new(File.read(file)).result).each do |attr, value|
         Hutch::Config.send("#{attr}=", value)
       end
     end

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -96,5 +96,15 @@ describe Hutch::Config do
         expect(Hutch::Config.mq_username).to eq username
       end
     end
+
+    context 'when using ERb' do
+      let(:config_data) { { mq_host: host, mq_username: '<%= "calvin" %>' } }
+
+      it 'loads in the config data' do
+        Hutch::Config.load_from_file(file)
+        expect(Hutch::Config.mq_host).to eq host
+        expect(Hutch::Config.mq_username).to eq username
+      end
+    end
   end
 end


### PR DESCRIPTION
Inspired by Rails, I found myself wanting a configuration file like this:

```yaml
uri: <%= ENV['AMQP_URL'] %>
require_paths:
  - raven
  - consumers
```
