### PR TITLE
Implement graceful exit

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -193,7 +193,9 @@ module Hutch
     end
 
     def stop
-      @channel.work_pool.kill
+      @channel.work_pool.shutdown # enqueues a failing job
+      @channel.work_pool.join(25)
+      @channel.work_pool.kill # kill is a job is running past the timeout
     end
 
     def requeue(delivery_tag)

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -43,7 +43,11 @@ module Hutch
         connection_timeout: 11,
         read_timeout: 11,
         write_timeout: 11,
-        enable_http_api_use: true
+        enable_http_api_use: true,
+        # Number of seconds that a running consumer is given
+        # to finish its job when gracefully exiting Hutch, before
+        # it's killed.
+        graceful_exit_timeout: 11,
       }.merge(params)
     end
 

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -211,6 +211,25 @@ describe Hutch::Broker do
     end
   end
 
+  describe '#stop' do
+    let(:thread_1) { double('Thread') }
+    let(:thread_2) { double('Thread') }
+    let(:work_pool) { double('Bunny::ConsumerWorkPool') }
+    let(:config) { { graceful_exit_timeout: 2 } }
+
+    before do
+      allow(broker).to receive(:channel_work_pool).and_return(work_pool)
+    end
+
+    it 'gracefully stops the work pool' do
+      expect(work_pool).to receive(:shutdown)
+      expect(work_pool).to receive(:join).with(2)
+      expect(work_pool).to receive(:kill)
+
+      broker.stop
+    end
+  end
+
   describe '#publish' do
     context 'with a valid connection' do
       before { broker.set_up_amqp_connection }


### PR DESCRIPTION
This is a follow up to #139, I realized that the documentation I added is not actually what happens.

On master, sending a SIGINT to hutch will just run `kill` on the worker pool. It's graceful in that it's killing the threads before exiting the program, but it's not really graceful in regards to what those threads are actually doing (ie, processing message).

With this PR I am implementing the following:

When sending `SIGINT`, `SIGQUIT`, or `SIGTERM` to Hutch, it will:

#### 1. Run `shutdown` on the `worker_pool`

It will set `working` to false in the pool, and enqueue an exception in the queue for each worker thread. Upon reception of the exception, the worker loop will end.

#### 2. Run `join` on all the threads

`#shutdown` kills the threads that were idling, but some workers were potentially already running so they won't get to the exception until their current job is done.

By calling `join`, we wait for `Hutch::Config[:graceful_exit_timeout]` seconds (defaults to 11 to be consistent with other timeouts default value) for the threads to finish (their next job in the queue is the exception).

#### 3. `kill` the remaining workers

After `graceful_exit_timeout` passed, we call `kill` on the worker_pool, which will kill the remaining workers that didn't finish their processing.

**note: ** I observed locally that jobs killed at step 3 are requeued. I can't find where that is defined (hutch, bunny, rabbitmq?), but I would like to add that to the README if that's indeed the expected behavior.


