### PR TITLE
Require erb for cli

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -1,4 +1,5 @@
 require 'hutch/error_handlers/logger'
+require 'erb'
 require 'logger'
 
 module Hutch


### PR DESCRIPTION
I was getting an error when trying to run the hutch cli:

```
/Users/ben/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/hutch-a99858756a67/lib/hutch/config.rb:85:
in `load_from_file': uninitialized constant Hutch::Config::ERB (NameError)
```

Explicitly requiring erb in the `Config` class file fixed it for me.