### PR TITLE
Basic support for tracing message processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 ## 0.15.0 — (unreleased)
 
+### Custom Arguments per Consumers
+
 Allow to set custom arguments per consumers by using the `arguments` setter.
 Arguments are usually used by rabbitmq plugins or to set queue policies. You can
 find a list of supported arguments [here](https://www.rabbitmq.com/extensions.html).
 
 Contributed by Pierre-Louis Gottfrois.
+
+### Message Processing Tracers
+
+Allow to track message processing by using the `:tracer` config option.
+NewRelic custom instrumentation is included.
+
+Contributed by Mirosław Nagaś.
 
 ## 0.14.0 — Feb 23rd, 2015
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem "sentry-raven"
   gem "honeybadger"
   gem "coveralls", require: false
+  gem "newrelic_rpm"
 end
 
 group :development, :darwin do

--- a/README.md
+++ b/README.md
@@ -105,15 +105,11 @@ to learn more.
 
 ### Message Processing Tracers
 
-Tracers allow you to track message processing. You can set them using `tracer` method.
+Tracers allow you to track message processing.
 
 #### NewRelic
 ```ruby
-class FailedPaymentConsumer
-  include Hutch::Consumer
-  consume 'gc.ps.payment.failed'
-  tracer 'NewRelic'
-end
+Hutch::Config.set(:tracer, Hutch::Tracers::NewRelic)
 ```
 This will enable NewRelic custom instrumentation. Batteries included! Screenshoots available [here](https://monosnap.com/list/557020a000779174f23467e3).
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ Hutch::Logging.logger = Rails.logger
 See this [RabbitMQ tutorial on topic exchanges](http://www.rabbitmq.com/tutorials/tutorial-five-ruby.html)
 to learn more.
 
+### Message Processing Tracers
+
+Tracers allow you to track message processing. You can set them using `tracer` method.
+
+#### NewRelic
+```ruby
+class FailedPaymentConsumer
+  include Hutch::Consumer
+  consume 'gc.ps.payment.failed'
+  tracer 'NewRelic'
+end
+```
+This will enable NewRelic custom instrumentation. Batteries included! Screenshoots available [here](https://monosnap.com/list/557020a000779174f23467e3).
 
 ## Running Hutch
 
@@ -271,6 +284,7 @@ Known configuration parameters are:
  * `connection_timeout`: Bunny's socket open timeout (default: `11`)
  * `read_timeout`: Bunny's socket read timeout (default: `11`)
  * `write_timemout`: Bunny's socket write timeout (default: `11`)
+ * `tracer`: tracer to use to track message processing
 
 
 ## Supported RabbitMQ Versions

--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -8,6 +8,7 @@ require 'hutch/cli'
 require 'hutch/version'
 require 'hutch/error_handlers'
 require 'hutch/exceptions'
+require 'hutch/tracers'
 
 module Hutch
 

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -24,6 +24,12 @@ module Hutch
         logger.info "HTTP API use is disabled"
       end
 
+      if tracing_enabled?
+        logger.info "tracing is enabled using #{@config[:tracer]}"
+      else
+        logger.info "tracing is disabled"
+      end
+
       if block_given?
         begin
           yield
@@ -138,6 +144,10 @@ module Hutch
            end
 
       op && cf
+    end
+
+    def tracing_enabled?
+      @config[:tracer] && @config[:tracer] != Hutch::Tracers::NullTracer
     end
 
     # Create / get a durable queue and apply namespace if it exists.

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -30,6 +30,7 @@ module Hutch
         require_paths: [],
         autoload_rails: true,
         error_handlers: [Hutch::ErrorHandlers::Logger.new],
+        tracer: nil,
         namespace: nil,
         daemonise: false,
         pidfile: nil,

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -30,7 +30,7 @@ module Hutch
         require_paths: [],
         autoload_rails: true,
         error_handlers: [Hutch::ErrorHandlers::Logger.new],
-        tracer: nil,
+        tracer: Hutch::Tracers::NullTracer,
         namespace: nil,
         daemonise: false,
         pidfile: nil,
@@ -85,7 +85,16 @@ module Hutch
 
     def self.load_from_file(file)
       YAML.load(ERB.new(File.read(file)).result).each do |attr, value|
-        Hutch::Config.send("#{attr}=", value)
+        Hutch::Config.send("#{attr}=", convert_value(attr, value))
+      end
+    end
+
+    def self.convert_value(attr, value)
+      case attr
+      when "tracer"
+        Kernel.const_get(value)
+      else
+        value
       end
     end
 

--- a/lib/hutch/tracers.rb
+++ b/lib/hutch/tracers.rb
@@ -1,0 +1,12 @@
+module Hutch
+  module Tracers
+    autoload :NullTracer, 'hutch/tracers/null_tracer'
+
+    TRACERS = {
+    }
+
+    def self.[](key)
+      TRACERS[key] || Hutch::Tracers::NullTracer
+    end
+  end
+end

--- a/lib/hutch/tracers.rb
+++ b/lib/hutch/tracers.rb
@@ -2,13 +2,5 @@ module Hutch
   module Tracers
     autoload :NullTracer, 'hutch/tracers/null_tracer'
     autoload :NewRelic,   'hutch/tracers/newrelic'
-
-    TRACERS = {
-      "NewRelic" => Hutch::Tracers::NewRelic
-    }
-
-    def self.[](key)
-      TRACERS[key] || Hutch::Tracers::NullTracer
-    end
   end
 end

--- a/lib/hutch/tracers.rb
+++ b/lib/hutch/tracers.rb
@@ -1,8 +1,10 @@
 module Hutch
   module Tracers
     autoload :NullTracer, 'hutch/tracers/null_tracer'
+    autoload :NewRelic,   'hutch/tracers/newrelic'
 
     TRACERS = {
+      "NewRelic" => Hutch::Tracers::NewRelic
     }
 
     def self.[](key)

--- a/lib/hutch/tracers/newrelic.rb
+++ b/lib/hutch/tracers/newrelic.rb
@@ -1,0 +1,19 @@
+require 'newrelic_rpm'
+
+module Hutch
+  module Tracers
+    class NewRelic
+      include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def handle(message)
+        @klass.process(message)
+      end
+
+      add_transaction_tracer :handle, :category => 'OtherTransaction/HutchConsumer', :path => '#{@klass.class.name}'
+    end
+  end
+end

--- a/lib/hutch/tracers/null_tracer.rb
+++ b/lib/hutch/tracers/null_tracer.rb
@@ -1,0 +1,15 @@
+module Hutch
+  module Tracers
+    class NullTracer
+
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def handle(message)
+        @klass.process(message)
+      end
+
+    end
+  end
+end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -81,12 +81,21 @@ module Hutch
       broker = @broker
       begin
         message = Message.new(delivery_info, properties, payload)
-        consumer.new.tap { |c| c.broker, c.delivery_info = @broker, delivery_info }.process(message)
+        consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = @broker, delivery_info }
+        with_tracing(consumer_instance).handle(message)
         broker.ack(delivery_info.delivery_tag)
       rescue StandardError => ex
         broker.nack(delivery_info.delivery_tag)
         handle_error(properties.message_id, payload, consumer, ex)
       end
+    end
+
+    def with_tracing(klass)
+      Hutch::Tracers[tracer_name].new(klass)
+    end
+
+    def tracer_name
+      Hutch::Config[:tracer]
     end
 
     def handle_error(message_id, payload, consumer, ex)

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -91,11 +91,7 @@ module Hutch
     end
 
     def with_tracing(klass)
-      Hutch::Tracers[tracer_name].new(klass)
-    end
-
-    def tracer_name
-      Hutch::Config[:tracer]
+      Hutch::Config[:tracer].new(klass)
     end
 
     def handle_error(message_id, payload, consumer, ex)


### PR DESCRIPTION
This adds a basic implementation for a pluggable message processing tracers.

Support for [NewRelic custom instrumentation](https://docs.newrelic.com/docs/agents/ruby-agent/features/ruby-custom-instrumentation) is included. It requires newrelic_rpm gem and I assume it's provided with Rails application.

Should be fairly easy expandable to other instrumentation sources as well.