### PR TITLE
Use HashWithIndifferentAccess instead of MultiJSON symbolize

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'bunny', '>= 1.7.0'
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.5'
+  gem.add_runtime_dependency 'activesupport', '>= 3.0'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
 

--- a/lib/hutch/message.rb
+++ b/lib/hutch/message.rb
@@ -1,5 +1,6 @@
 require 'multi_json'
 require 'forwardable'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Hutch
   class Message
@@ -11,7 +12,7 @@ module Hutch
       @delivery_info = delivery_info
       @properties    = properties
       @payload       = payload
-      @body          = MultiJson.load(payload, symbolize_keys: true)
+      @body          = MultiJson.load(payload).with_indifferent_access
     end
 
     def_delegator :@body, :[]

--- a/spec/hutch/message_spec.rb
+++ b/spec/hutch/message_spec.rb
@@ -3,7 +3,7 @@ require 'hutch/message'
 describe Hutch::Message do
   let(:delivery_info) { double('Delivery Info') }
   let(:props) { double('Properties') }
-  let(:body) {{ foo: 'bar' }}
+  let(:body) {{ foo: 'bar' }.with_indifferent_access}
   let(:json_body) { MultiJson.dump(body) }
   subject(:message) { Hutch::Message.new(delivery_info, props, json_body) }
 


### PR DESCRIPTION
Hi,

Using `symbolize: true` when loading JSON can lead to DoS since symbols are not garbage collected by ruby.

This PR replaces `MultiJSON.load(payload, symbolize_keys: true)` with `ActiveSupport::HashWithIndifferentAccess` in order to maintain backwards compatibility.