### PR TITLE
URI improvements

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -69,6 +69,7 @@ module Hutch
         @config[:mq_vhost]    = u.path.sub(/^\//, "")
         @config[:mq_username] = u.user
         @config[:mq_password] = u.password
+        @config[:mq_tls]      = u.scheme == "amqps"
       end
 
       host               = @config[:mq_host]

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -72,8 +72,9 @@ module Hutch
         @config[:mq_tls]      = u.scheme == "amqps"
       end
 
+      tls                = @config[:mq_tls]
       host               = @config[:mq_host]
-      port               = @config[:mq_port]
+      port               = @config[:mq_port] || tls ? 5671 : 5672
       vhost              = if @config[:mq_vhost] && "" != @config[:mq_vhost]
                              @config[:mq_vhost]
                            else
@@ -81,7 +82,6 @@ module Hutch
                            end
       username           = @config[:mq_username]
       password           = @config[:mq_password]
-      tls                = @config[:mq_tls]
       tls_key            = @config[:mq_tls_key]
       tls_cert           = @config[:mq_tls_cert]
       heartbeat          = @config[:heartbeat]


### PR DESCRIPTION
Respect "amqps://" in the URI and use the default protocol ports (5672 and 5671) if no port is supplied in the URI