### PR TITLE
Add worker_pool_size option for multithreaded consumers

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -74,8 +74,8 @@ module Hutch
     end
 
     def open_channel!
-      logger.info 'opening rabbitmq channel'
-      @channel = connection.create_channel.tap do |ch|
+      logger.info "opening rabbitmq channel with #{channel_work_pool_size} workers"
+      @channel = connection.create_channel(nil, channel_work_pool_size).tap do |ch|
         ch.prefetch(@config[:channel_prefetch]) if @config[:channel_prefetch]
         if @config[:publisher_confirms] || @config[:force_publisher_confirms]
           logger.info 'enabling publisher confirms'
@@ -338,6 +338,10 @@ module Hutch
 
     def channel_work_pool
       @channel.work_pool
+    end
+
+    def channel_work_pool_size
+      @config[:worker_pool_size]
     end
 
     def generate_id

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -74,8 +74,8 @@ module Hutch
     end
 
     def open_channel!
-      logger.info "opening rabbitmq channel with #{channel_work_pool_size} workers"
-      @channel = connection.create_channel(nil, channel_work_pool_size).tap do |ch|
+      logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}"
+      @channel = connection.create_channel(nil, consumer_pool_size).tap do |ch|
         ch.prefetch(@config[:channel_prefetch]) if @config[:channel_prefetch]
         if @config[:publisher_confirms] || @config[:force_publisher_confirms]
           logger.info 'enabling publisher confirms'
@@ -340,8 +340,8 @@ module Hutch
       @channel.work_pool
     end
 
-    def channel_work_pool_size
-      @config[:worker_pool_size]
+    def consumer_pool_size
+      @config[:consumer_pool_size]
     end
 
     def generate_id

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -51,6 +51,8 @@ module Hutch
         # it's killed.
         graceful_exit_timeout: 11,
         client_logger: nil,
+
+        worker_pool_size: 1,
       }.merge(params)
     end
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -52,7 +52,7 @@ module Hutch
         graceful_exit_timeout: 11,
         client_logger: nil,
 
-        worker_pool_size: 1,
+        consumer_pool_size: 1,
       }.merge(params)
     end
 


### PR DESCRIPTION
Add option to set bunny's worker pool size to allow for multithreaded consumers. Will probably want to add standard disclaimers about concurrency and databases, etc.

Related to https://github.com/gocardless/hutch/issues/141