### PR TITLE
Add MarchHare support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ rvm:
   - "2.2"
   - "2.1"
   - "2.0"
+  - "jruby-9.0.0.0"
 services:
   - rabbitmq
+matrix:
+  allow_failures:
+    - rvm: jruby-9.0.0.0

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -1,7 +1,13 @@
 require File.expand_path('../lib/hutch/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'bunny', '>= 1.7.0'
+  if defined?(JRUBY_VERSION)
+    gem.platform = 'java'
+    gem.add_runtime_dependency 'march_hare', '>= 2.11.0'
+  else
+    gem.platform = Gem::Platform::RUBY
+    gem.add_runtime_dependency 'bunny', '>= 1.7.0'
+  end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.5'
   gem.add_runtime_dependency 'activesupport', '>= 3.0'

--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -1,3 +1,4 @@
+require 'hutch/adapter'
 require 'hutch/consumer'
 require 'hutch/worker'
 require 'hutch/broker'
@@ -57,4 +58,3 @@ module Hutch
     broker.publish(*args)
   end
 end
-

--- a/lib/hutch/adapter.rb
+++ b/lib/hutch/adapter.rb
@@ -1,0 +1,11 @@
+if defined?(JRUBY_VERSION)
+  require 'hutch/adapters/march_hare'
+  module Hutch
+    Adapter = Adapters::MarchHareAdapter
+  end
+else
+  require 'hutch/adapters/bunny'
+  module Hutch
+    Adapter = Adapters::BunnyAdapter
+  end
+end

--- a/lib/hutch/adapters/bunny.rb
+++ b/lib/hutch/adapters/bunny.rb
@@ -17,6 +17,10 @@ module Hutch
         @connection = Bunny.new(opts)
       end
 
+      def self.decode_message(delivery_info, properties, payload)
+        [delivery_info, properties, payload]
+      end
+
       def prefetch_channel(ch, prefetch)
         ch.prefetch(prefetch) if prefetch
       end

--- a/lib/hutch/adapters/bunny.rb
+++ b/lib/hutch/adapters/bunny.rb
@@ -1,12 +1,25 @@
 require 'bunny'
+require 'forwardable'
 
 module Hutch
   module Adapters
     class BunnyAdapter
+      extend Forwardable
+
       DEFAULT_VHOST = Bunny::Session::DEFAULT_VHOST
+
+      def_delegators :@connection, :start, :disconnect, :close, :create_channel, :open?
+
+      def initialize(opts={})
+        @connection = Bunny.new(opts)
+      end
 
       def prefetch_channel(ch, prefetch)
         ch.prefetch(prefetch) if prefetch
+      end
+
+      def current_timestamp
+        Time.now.to_i
       end
     end
   end

--- a/lib/hutch/adapters/bunny.rb
+++ b/lib/hutch/adapters/bunny.rb
@@ -1,0 +1,13 @@
+require 'bunny'
+
+module Hutch
+  module Adapters
+    class BunnyAdapter
+      DEFAULT_VHOST = Bunny::Session::DEFAULT_VHOST
+
+      def prefetch_channel(ch, prefetch)
+        ch.prefetch(prefetch) if prefetch
+      end
+    end
+  end
+end

--- a/lib/hutch/adapters/bunny.rb
+++ b/lib/hutch/adapters/bunny.rb
@@ -8,6 +8,9 @@ module Hutch
 
       DEFAULT_VHOST = Bunny::Session::DEFAULT_VHOST
 
+      ConnectionRefused = Bunny::TCPConnectionFailed
+      PreconditionFailed = Bunny::PreconditionFailed
+
       def_delegators :@connection, :start, :disconnect, :close, :create_channel, :open?
 
       def initialize(opts={})

--- a/lib/hutch/adapters/march_hare.rb
+++ b/lib/hutch/adapters/march_hare.rb
@@ -17,6 +17,10 @@ module Hutch
         @connection = MarchHare.connect(opts)
       end
 
+      def self.decode_message(delivery_info, payload)
+        [delivery_info, delivery_info.properties, payload]
+      end
+
       def prefetch_channel(ch, prefetch)
         ch.prefetch = prefetch if prefetch
       end

--- a/lib/hutch/adapters/march_hare.rb
+++ b/lib/hutch/adapters/march_hare.rb
@@ -1,12 +1,29 @@
 require 'march_hare'
+require 'forwardable'
 
 module Hutch
   module Adapters
     class MarchHareAdapter
+      extend Forwardable
+
       DEFAULT_VHOST = "/"
+
+      def_delegators :@connection, :start, :disconnect, :close, :open?
+
+      def initialize(opts = {})
+        @connection = MarchHare.connect(opts)
+      end
 
       def prefetch_channel(ch, prefetch)
         ch.prefetch = prefetch if prefetch
+      end
+
+      def create_channel(n = nil, consumer_pool_size = 1)
+        @connection.create_channel(n)
+      end
+
+      def current_timestamp
+        Time.now
       end
     end
   end

--- a/lib/hutch/adapters/march_hare.rb
+++ b/lib/hutch/adapters/march_hare.rb
@@ -8,6 +8,9 @@ module Hutch
 
       DEFAULT_VHOST = "/"
 
+      ConnectionRefused = MarchHare::ConnectionRefused
+      PreconditionFailed = MarchHare::PreconditionFailed
+
       def_delegators :@connection, :start, :disconnect, :close, :open?
 
       def initialize(opts = {})

--- a/lib/hutch/adapters/march_hare.rb
+++ b/lib/hutch/adapters/march_hare.rb
@@ -1,0 +1,13 @@
+require 'march_hare'
+
+module Hutch
+  module Adapters
+    class MarchHareAdapter
+      DEFAULT_VHOST = "/"
+
+      def prefetch_channel(ch, prefetch)
+        ch.prefetch = prefetch if prefetch
+      end
+    end
+  end
+end

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -167,12 +167,16 @@ module Hutch
     end
 
     def stop
-      # Enqueue a failing job that kills the consumer loop
-      channel_work_pool.shutdown
-      # Give `timeout` seconds to jobs that are still being processed
-      channel_work_pool.join(@config[:graceful_exit_timeout])
-      # If after `timeout` they are still running, they are killed
-      channel_work_pool.kill
+      if defined?(JRUBY_VERSION)
+        @channel.close
+      else
+        # Enqueue a failing job that kills the consumer loop
+        channel_work_pool.shutdown
+        # Give `timeout` seconds to jobs that are still being processed
+        channel_work_pool.join(@config[:graceful_exit_timeout])
+        # If after `timeout` they are still running, they are killed
+        channel_work_pool.kill
+      end
     end
 
     def requeue(delivery_tag)

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -1,4 +1,3 @@
-require 'bunny'
 require 'carrot-top'
 require 'securerandom'
 require 'hutch/logging'
@@ -76,7 +75,7 @@ module Hutch
     def open_channel!
       logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}"
       @channel = connection.create_channel(nil, consumer_pool_size).tap do |ch|
-        ch.prefetch(@config[:channel_prefetch]) if @config[:channel_prefetch]
+        Hutch::Adapter.prefetch_channel(ch, @config[:channel_prefetch])
         if @config[:publisher_confirms] || @config[:force_publisher_confirms]
           logger.info 'enabling publisher confirms'
           ch.confirm_select
@@ -259,7 +258,7 @@ module Hutch
         params[:vhost]              = if @config[:mq_vhost] && "" != @config[:mq_vhost]
                                         @config[:mq_vhost]
                                       else
-                                        Bunny::Session::DEFAULT_VHOST
+                                        Hutch::Adapter::DEFAULT_VHOST
                                       end
         params[:username]           = @config[:mq_username]
         params[:password]           = @config[:mq_password]
@@ -353,4 +352,3 @@ module Hutch
     end
   end
 end
-

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -168,7 +168,7 @@ module Hutch
 
     def stop
       if defined?(JRUBY_VERSION)
-        @channel.close
+        channel.close
       else
         # Enqueue a failing job that kills the consumer loop
         channel_work_pool.shutdown

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -317,7 +317,7 @@ module Hutch
 
     def with_bunny_precondition_handler(item)
       yield
-    rescue Bunny::PreconditionFailed => ex
+    rescue Hutch::Adapter::PreconditionFailed => ex
       logger.error ex.message
       s = "RabbitMQ responded with 406 Precondition Failed when creating this #{item}. " +
           "Perhaps it is being redeclared with non-matching attributes"
@@ -326,7 +326,7 @@ module Hutch
 
     def with_bunny_connection_handler(uri)
       yield
-    rescue Bunny::TCPConnectionFailed => ex
+    rescue Hutch::Adapter::ConnectionRefused => ex
       logger.error "amqp connection error: #{ex.message.downcase}"
       raise ConnectionError.new("couldn't connect to rabbitmq at #{uri}. Check your configuration, network connectivity and RabbitMQ logs.")
     end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -65,7 +65,8 @@ module Hutch
       queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
       @broker.bind_queue(queue, consumer.routing_keys)
 
-      queue.subscribe(manual_ack: true) do |delivery_info, properties, payload|
+      queue.subscribe(manual_ack: true) do |*args|
+        delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
         handle_message(consumer, delivery_info, properties, payload)
       end
     end

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -240,7 +240,7 @@ describe Hutch::Broker do
     end
   end
 
-  describe '#stop' do
+  describe '#stop', adapter: :bunny do
     let(:thread_1) { double('Thread') }
     let(:thread_2) { double('Thread') }
     let(:work_pool) { double('Bunny::ConsumerWorkPool') }
@@ -254,6 +254,20 @@ describe Hutch::Broker do
       expect(work_pool).to receive(:shutdown)
       expect(work_pool).to receive(:join).with(2)
       expect(work_pool).to receive(:kill)
+
+      broker.stop
+    end
+  end
+
+  describe '#stop', adapter: :march_hare do
+    let(:channel) { double('MarchHare::Channel')}
+
+    before do
+      allow(broker).to receive(:channel).and_return(channel)
+    end
+
+    it 'gracefully stops the channel' do
+      expect(channel).to receive(:close)
 
       broker.stop
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,12 @@ require 'logger'
 RSpec.configure do |config|
   config.before(:all) { Hutch::Config.log_level = Logger::FATAL }
   config.raise_errors_for_deprecations!
+
+  if defined?(JRUBY_VERSION)
+    config.filter_run_excluding adapter: :bunny
+  else
+    config.filter_run_excluding adapter: :march_hare
+  end
 end
 
 # Constants (classes, etc) defined within a block passed to this method
@@ -32,4 +38,3 @@ end
 def deep_copy(obj)
   Marshal.load(Marshal.dump(obj))
 end
-


### PR DESCRIPTION
Hi,

This PR ads [march_hare](https://github.com/ruby-amqp/march_hare) support. I don't consider it complete, since I didn't test all the cases. The test suite passes, and I also tested it using my application that was already using hutch. 

However, I didn't test all the options passed to `MarchHare.connect` since I don't have an app to test it. Also I'm not sure if I'm properly using the signals inside the main loop, but it seems to work. 

The only part which I'm not sure how to do is handling `ConnectionError`. When rabbitmq is stopped, or there is a network failure, it seems that MarchHare is calling the shutdown handler, not trying to reconnect.

I'm sorry if I'm missing something, this is my first contact with MarchHare internals.