### PR TITLE
Added two missing SSL config options to pass on to bunny

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -269,6 +269,8 @@ module Hutch
         params[:tls]                = @config[:mq_tls]
         params[:tls_key]            = @config[:mq_tls_key]
         params[:tls_cert]           = @config[:mq_tls_cert]
+        params[:verify_peer]        = @config[:mq_verify_peer]
+        params[:tls_ca_certificates] = @config[:mq_tls_ca_certificates]
         params[:heartbeat]          = @config[:heartbeat]
         params[:connection_timeout] = @config[:connection_timeout]
         params[:read_timeout]       = @config[:read_timeout]

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -270,7 +270,9 @@ module Hutch
         params[:tls_key]            = @config[:mq_tls_key]
         params[:tls_cert]           = @config[:mq_tls_cert]
         params[:verify_peer]        = @config[:mq_verify_peer]
-        params[:tls_ca_certificates] = @config[:mq_tls_ca_certificates]
+        if @config[:mq_tls_ca_certificates]
+          params[:tls_ca_certificates] = @config[:mq_tls_ca_certificates]
+        end
         params[:heartbeat]          = @config[:heartbeat]
         params[:connection_timeout] = @config[:connection_timeout]
         params[:read_timeout]       = @config[:read_timeout]

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -17,6 +17,8 @@ module Hutch
         mq_tls: false,
         mq_tls_cert: nil,
         mq_tls_key: nil,
+        mq_tls_ca_certificates: nil,
+        mq_verify_peer: nil,
         mq_username: 'guest',
         mq_password: 'guest',
         mq_api_host: 'localhost',

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -18,7 +18,7 @@ module Hutch
         mq_tls_cert: nil,
         mq_tls_key: nil,
         mq_tls_ca_certificates: nil,
-        mq_verify_peer: nil,
+        mq_verify_peer: true,
         mq_username: 'guest',
         mq_password: 'guest',
         mq_api_host: 'localhost',


### PR DESCRIPTION
verify_peer and tls_ca_certificates

These are probably obscure enough to not need cli option support, but are very important when using self-signed certificates etc.

Verify_peer defaults to true (the same as the bunny default) and tls_ca_certificates is passed on if you actually set it.