### PR TITLE
`#ack` following `#requeue` causes exit

### DIFF
--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -62,6 +62,24 @@ describe Hutch::Worker do
       worker.handle_message(consumer, delivery_info, properties, payload)
     end
 
+    context 'when the consumer requeues a message' do
+      class Rejecter
+        include Hutch::Consumer
+
+        def process(message)
+          requeue!
+        end
+      end
+
+      it 'requeues the message', :focus do
+        expect(broker).to_not receive(:ack)
+        expect(broker).to_not receive(:nack)
+        expect(broker).to receive(:requeue)
+
+        worker.handle_message(Rejecter, delivery_info, properties, payload)
+      end
+    end
+
     context 'when the consumer raises an exception' do
       before { allow(consumer_instance).to receive(:process).and_raise('a consumer error') }
 


### PR DESCRIPTION
I have a hutch worker similar to the following:

``` ruby
class MyConsumer
  queue 'foo'

  def process(message)
    begin
      # ...
    rescue => e
      if e.is_a?(EphemeralError)
        requeue!
      else
        raise e
      end
    end
  end
end
```

This causes the process to shut down gracefully. Apparently, the `requeue!` sends off a `@channel.reject(delivery_tag, true)` and then exits the `Consumer` process method. Within the `Worker#handle_message` method, it then calls `broker.ack(delivery_info.delivery_tag)`. After this point the channel is closed, which seems to indicate that rabbitmq drops the connection when an ack follows a reject.

I created a test to show that ack is called after a reject.

We need some way to prevent this. A couple of ideas:

1) Add a property to `Hutch::Message` that indicates if there was already some ack/nack/reject action taken on the message within the process method. If so, do not attempt ack/nack from `Worker#handle_message`.

2) Remove the nack from the rescue block of `Worker#handle_message`. Instead, rely on a default `ErrorHandler` to do the nack and allow users to specify their own error handler that could examine the error and decide wither to nack/reject/requeue. This might have to cause a breaking change for anyone who manually sets `Hutch::Config.set :error_handlers, [..]`