### PR TITLE
bunny accepts logger parameter

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -294,7 +294,7 @@ module Hutch
         params[:automatically_recover] = true
         params[:network_recovery_interval] = 1
 
-        params[:client_logger] = @config[:client_logger] if @config[:client_logger]
+        params[:logger] = @config[:client_logger] if @config[:client_logger]
       end
     end
 


### PR DESCRIPTION
According to bunny's connection document[0], Bunny#new accepts :logger parameter rather than :client_logger.

[0] http://rubybunny.info/articles/connecting.html