### PR TITLE
Check existence of rails file to detect Rails app

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -65,9 +65,13 @@ module Hutch
     def load_rails_app(path)
       # path should point to the app's top level directory
       if File.directory?(path)
-        # Smells like a Rails app if it's got a config/environment.rb file
+        # Smells like a Rails app if it's got a script/rails or bin/rails file
+        is_rails_app = false
+        ['script/rails', 'bin/rails'].each do |file|
+          is_rails_app = true if File.exist?(File.expand_path(File.join(path, file)))
+        end
         rails_path = File.expand_path(File.join(path, 'config/environment.rb'))
-        if File.exists?(rails_path)
+        if is_rails_app && File.exist?(rails_path)
           logger.info "found rails project (#{path}), booting app"
           ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || 'development'
           require rails_path


### PR DESCRIPTION
It throws following error in my non rails app.
```ruby 
ruby-2.3.0/gems/hutch-0.20.0/lib/hutch/cli.rb:74:in `load_rails_app': uninitialized constant Rails (NameError)
```
 There is config/environment.rb file in my app and it assumes that app is Rails app. But thats not the case. So I have adjusted the rails app detection logic and its working in my test env for both rails/non rails apps.  Any suggestions on using config/environment.rb file?

