### PR TITLE
Print load error exception in hutch executable

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -42,8 +42,8 @@ module Hutch
           # Need to add '.' to load path for relative requires
           $LOAD_PATH << '.'
           require path
-        rescue LoadError
-          logger.fatal "could not load file '#{path}'"
+        rescue LoadError => e
+          logger.fatal "could not load file '#{path}': #{e}"
           return false
         ensure
           # Clean up load path


### PR DESCRIPTION
I encountered problems in my consumer (failing to `bundle exec`) and found them hard to debug without output.


