### PR TITLE
Re-enable JRuby support by requiring exception classes based on platform

### DIFF
--- a/lib/hutch/exceptions.rb
+++ b/lib/hutch/exceptions.rb
@@ -1,8 +1,12 @@
-require "bunny/exceptions"
-
 module Hutch
-  # Bunny::Exception inherits from StandardError
-  class Exception < Bunny::Exception; end
+  if defined?(JRUBY_VERSION)
+    require 'march_hare/exceptions'
+    class Exception < MarchHare::Exception; end
+  else
+    require "bunny/exceptions"
+    # Bunny::Exception inherits from StandardError
+    class Exception < Bunny::Exception; end
+  end
   class ConnectionError < Exception; end
   class AuthenticationError < Exception; end
   class WorkerSetupError < Exception; end


### PR DESCRIPTION
I could load Hutch on JRuby because it tries to load exceptions from Bunny regardless of which platform it's running on. 
This PR supports March Hare exceptions the same way that Bunny exceptions are handled for MRI.