### PR TITLE
Publish from separate channels per thread

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -39,6 +39,7 @@ module Hutch
     end
 
     def disconnect
+      clear_thread_store
       @channel.close    if @channel
       @connection.close if @connection
       @channel, @connection, @exchange, @api_client = nil, nil, nil, nil
@@ -51,13 +52,20 @@ module Hutch
       open_connection!
       open_channel!
 
-      exchange_name = @config[:mq_exchange]
-      exchange_options = { durable: true }.merge @config[:mq_exchange_options]
-      logger.info "using topic exchange '#{exchange_name}'"
+      @exchange = set_up_exchange(@channel)
 
-      with_bunny_precondition_handler('exchange') do
-        @exchange = @channel.topic(exchange_name, exchange_options)
+      if !thread_store[:publish_channel] and !thread_store[:publish_exchange]
+        thread_store[:publish_channel] ||= @channel
+        thread_store[:publish_exchange] ||= @exchange
       end
+    end
+
+    def publish_channel
+      thread_store[:publish_channel] ||= set_up_publish_channel
+    end
+
+    def publish_exchange
+      thread_store[:publish_exchange] ||= set_up_exchange(publish_channel)
     end
 
     def open_connection!
@@ -74,14 +82,7 @@ module Hutch
     end
 
     def open_channel!
-      logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}, abort on exception #{consumer_pool_abort_on_exception}"
-      @channel = @connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
-        @connection.prefetch_channel(ch, @config[:channel_prefetch])
-        if @config[:publisher_confirms] || @config[:force_publisher_confirms]
-          logger.info 'enabling publisher confirms'
-          ch.confirm_select
-        end
-      end
+      @channel = set_up_consumers_channel
     end
 
     # Set up the connection to the RabbitMQ management API. Unfortunately, this
@@ -219,12 +220,12 @@ module Hutch
         "publishing #{spec} to #{routing_key}"
       }
 
-      response = @exchange.publish(payload, {persistent: true}.
+      response = publish_exchange.publish(payload, {persistent: true}.
         merge(properties).
         merge(global_properties).
         merge(non_overridable_properties))
 
-      channel.wait_for_confirms if @config[:force_publisher_confirms]
+      publish_channel.wait_for_confirms if @config[:force_publisher_confirms]
       response
     end
 
@@ -375,5 +376,60 @@ module Hutch
       Hutch.global_properties.respond_to?(:call) ? Hutch.global_properties.call : Hutch.global_properties
     end
 
+    def thread_store
+      Thread.current["hutch_broker_#{object_id}"] ||= {}
+    end
+
+    def clear_thread_store
+      Thread.list.each do |t|
+        next unless t["hutch_broker_#{object_id}"]
+
+        ch = t["hutch_broker_#{object_id}"][:publish_channel]
+
+        if ch and ch != @channel
+          ch.close
+        end
+
+        t["hutch_broker_#{object_id}"] = nil
+      end
+    end
+
+    def set_up_consumers_channel
+      logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}, abort on exception #{consumer_pool_abort_on_exception}"
+
+      @connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
+        @connection.prefetch_channel(ch, @config[:channel_prefetch])
+        use_publisher_confirms_if_needed(ch)
+      end
+    end
+
+    def set_up_publish_channel
+      return unless @connection
+
+      logger.info 'opening rabbitmq channel for publishing'
+
+      @connection.create_channel.tap do |ch|
+        use_publisher_confirms_if_needed(ch)
+      end
+    end
+
+    def use_publisher_confirms_if_needed(ch)
+      if @config[:publisher_confirms] || @config[:force_publisher_confirms]
+        logger.info "enabling publisher confirms on channel #{ch.id}"
+        ch.confirm_select
+      end
+    end
+
+    def set_up_exchange(ch)
+      return unless ch
+
+      exchange_name = @config[:mq_exchange]
+      exchange_options = { durable: true }.merge @config[:mq_exchange_options]
+      logger.info "using topic exchange '#{exchange_name}'"
+
+      with_bunny_precondition_handler('exchange') do
+        ch.topic(exchange_name, exchange_options)
+      end
+    end
   end
 end

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -82,7 +82,6 @@ describe Hutch::Broker do
       expect(broker.channel).to be_nil
       expect(broker.exchange).to be_nil
       expect(broker.publish_channel).to be_nil
-      expect(broker.publish_exchange).to be_nil
       expect(broker.api_client).to be_nil
       expect(t["hutch_broker_#{broker.object_id}"]).to be_nil # XXX hack: the key is private
     end
@@ -126,11 +125,6 @@ describe Hutch::Broker do
       describe '#publish_channel' do
         subject { super().publish_channel }
         it { is_expected.to eq(broker.channel) }
-      end
-
-      describe '#publish_exchange', adapter: :march_hare do
-        subject { super().publish_exchange }
-        it { is_expected.to eq(broker.exchange) }
       end
     end
 
@@ -208,10 +202,10 @@ describe Hutch::Broker do
     end
   end
 
-  describe '#publish_exchange' do
+  describe '#exchange' do
     context 'without a valid connection' do
       it 'returns nil' do
-        expect(broker.publish_channel).to be_nil
+        expect(broker.exchange).to be_nil
       end
     end
 
@@ -222,7 +216,7 @@ describe Hutch::Broker do
         expect(broker).to receive(:publish_channel).and_return(ch)
         expect(ch).to receive(:topic)
 
-        broker.publish_exchange
+        broker.exchange
       end
     end
   end
@@ -458,18 +452,18 @@ describe Hutch::Broker do
       context 'with multiple threads' do
         it 'uses different channels per thread' do
           main_publish_channel  = broker.publish_channel
-          main_publish_exchange = broker.publish_exchange
+          main_exchange = broker.exchange
 
-          expect(main_publish_exchange).to receive(:publish)
+          expect(main_exchange).to receive(:publish)
 
           broker.publish('test.key', 'message')
 
           Thread.new do
             expect(broker.publish_channel).not_to  eq(main_publish_channel)
-            expect(broker.publish_exchange).not_to eq(main_publish_exchange)
-            expect(broker.publish_exchange.channel).not_to eq(main_publish_exchange.channel)
+            expect(broker.exchange).not_to eq(main_exchange)
+            expect(broker.exchange.channel).not_to eq(main_exchange.channel)
 
-            expect(broker.publish_exchange).to receive(:publish)
+            expect(broker.exchange).to receive(:publish)
             broker.publish('test.key', 'message')
           end.join
         end


### PR DESCRIPTION
Add Hutch::Broker#publish_channel and Hutch::Broker#publish_exchange
that setup a new channel and exchange per thread when used.
Change Hutch::Broker#publish to use #publish_exchange and #publish_channel

resolve gocardless/hutch#191

I am not sure what to do with the part that shares the first channel with current thread in `Hutch::Broker#set_up_amqp_connection`. If it is removed, there will be a clear separation between channels used for publishing and the channel that is used for subscribing.

@michaelklishin 