### PR TITLE
Versatile broker

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -50,38 +50,53 @@ module Hutch
     def set_up_amqp_connection
       open_connection!
       open_channel!
-
-      exchange_name = @config[:mq_exchange]
-      exchange_options = { durable: true }.merge @config[:mq_exchange_options]
-      logger.info "using topic exchange '#{exchange_name}'"
-
-      with_bunny_precondition_handler('exchange') do
-        @exchange = channel.topic(exchange_name, exchange_options)
-      end
+      declare_exchange!
     end
 
-    def open_connection!
+    def open_connection
       logger.info "connecting to rabbitmq (#{sanitized_uri})"
 
-      @connection = Hutch::Adapter.new(connection_params)
+      connection = Hutch::Adapter.new(connection_params)
 
       with_bunny_connection_handler(sanitized_uri) do
-        @connection.start
+        connection.start
       end
 
       logger.info "connected to RabbitMQ at #{connection_params[:host]} as #{connection_params[:username]}"
-      @connection
+      connection
     end
 
-    def open_channel!
+    def open_connection!
+      @connection = open_connection
+    end
+
+    def open_channel
       logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}, abort on exception #{consumer_pool_abort_on_exception}"
-      @channel = connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
+      connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
         connection.prefetch_channel(ch, @config[:channel_prefetch])
         if @config[:publisher_confirms] || @config[:force_publisher_confirms]
           logger.info 'enabling publisher confirms'
           ch.confirm_select
         end
       end
+    end
+
+    def open_channel!
+      @channel = open_channel
+    end
+
+    def declare_exchange(ch = channel)
+      exchange_name = @config[:mq_exchange]
+      exchange_options = { durable: true }.merge @config[:mq_exchange_options]
+      logger.info "using topic exchange '#{exchange_name}'"
+
+      with_bunny_precondition_handler('exchange') do
+        ch.topic(exchange_name, exchange_options)
+      end
+    end
+
+    def declare_exchange!(*args)
+      @exchange = declare_exchange(*args)
     end
 
     # Set up the connection to the RabbitMQ management API. Unfortunately, this

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -56,7 +56,7 @@ module Hutch
       logger.info "using topic exchange '#{exchange_name}'"
 
       with_bunny_precondition_handler('exchange') do
-        @exchange = @channel.topic(exchange_name, exchange_options)
+        @exchange = channel.topic(exchange_name, exchange_options)
       end
     end
 
@@ -75,8 +75,8 @@ module Hutch
 
     def open_channel!
       logger.info "opening rabbitmq channel with pool size #{consumer_pool_size}, abort on exception #{consumer_pool_abort_on_exception}"
-      @channel = @connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
-        @connection.prefetch_channel(ch, @config[:channel_prefetch])
+      @channel = connection.create_channel(nil, consumer_pool_size, consumer_pool_abort_on_exception).tap do |ch|
+        connection.prefetch_channel(ch, @config[:channel_prefetch])
         if @config[:publisher_confirms] || @config[:force_publisher_confirms]
           logger.info 'enabling publisher confirms'
           ch.confirm_select
@@ -127,7 +127,7 @@ module Hutch
     # Return a mapping of queue names to the routing keys they're bound to.
     def bindings
       results = Hash.new { |hash, key| hash[key] = [] }
-      @api_client.bindings.each do |binding|
+      api_client.bindings.each do |binding|
         next if binding['destination'] == binding['routing_key']
         next unless binding['source'] == @config[:mq_exchange]
         next unless binding['vhost'] == @config[:mq_vhost]
@@ -146,7 +146,7 @@ module Hutch
         queue_bindings.each do |dest, keys|
           keys.reject { |key| routing_keys.include?(key) }.each do |key|
             logger.debug "removing redundant binding #{queue.name} <--> #{key}"
-            queue.unbind(@exchange, routing_key: key)
+            queue.unbind(exchange, routing_key: key)
           end
         end
       end
@@ -154,7 +154,7 @@ module Hutch
       # Ensure all the desired bindings are present
       routing_keys.each do |routing_key|
         logger.debug "creating binding #{queue.name} <--> #{routing_key}"
-        queue.bind(@exchange, routing_key: routing_key)
+        queue.bind(exchange, routing_key: routing_key)
       end
     end
 
@@ -181,19 +181,19 @@ module Hutch
     end
 
     def requeue(delivery_tag)
-      @channel.reject(delivery_tag, true)
+      channel.reject(delivery_tag, true)
     end
 
     def reject(delivery_tag, requeue=false)
-      @channel.reject(delivery_tag, requeue)
+      channel.reject(delivery_tag, requeue)
     end
 
     def ack(delivery_tag)
-      @channel.ack(delivery_tag, false)
+      channel.ack(delivery_tag, false)
     end
 
     def nack(delivery_tag)
-      @channel.nack(delivery_tag, false, false)
+      channel.nack(delivery_tag, false, false)
     end
 
     def publish(routing_key, message, properties = {}, options = {})
@@ -203,7 +203,7 @@ module Hutch
 
       non_overridable_properties = {
         routing_key:  routing_key,
-        timestamp:    @connection.current_timestamp,
+        timestamp:    connection.current_timestamp,
         content_type: serializer.content_type,
       }
       properties[:message_id]   ||= generate_id
@@ -219,7 +219,7 @@ module Hutch
         "publishing #{spec} to #{routing_key}"
       }
 
-      response = @exchange.publish(payload, {persistent: true}.
+      response = exchange.publish(payload, {persistent: true}.
         merge(properties).
         merge(global_properties).
         merge(non_overridable_properties))
@@ -229,15 +229,15 @@ module Hutch
     end
 
     def confirm_select(*args)
-      @channel.confirm_select(*args)
+      channel.confirm_select(*args)
     end
 
     def wait_for_confirms
-      @channel.wait_for_confirms
+      channel.wait_for_confirms
     end
 
     def using_publisher_confirmations?
-      @channel.using_publisher_confirmations?
+      channel.using_publisher_confirmations?
     end
 
     private
@@ -249,8 +249,8 @@ module Hutch
     end
 
     def ensure_connection!(routing_key, message)
-      raise_publish_error('no connection to broker', routing_key, message) unless @connection
-      raise_publish_error('connection is closed', routing_key, message) unless @connection.open?
+      raise_publish_error('no connection to broker', routing_key, message) unless connection
+      raise_publish_error('connection is closed', routing_key, message) unless connection.open?
     end
 
     def api_config
@@ -356,7 +356,7 @@ module Hutch
     end
 
     def channel_work_pool
-      @channel.work_pool
+      channel.work_pool
     end
 
     def consumer_pool_size

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -76,6 +76,26 @@ describe Hutch::Broker do
       before { config[:mq_host] = 'notarealhost' }
       it { expect { broker.open_connection }.to raise_error(StandardError) }
     end
+
+    it 'does not set #connection' do
+      connection = broker.open_connection
+
+      expect(broker.connection).to be_nil
+
+      connection.close
+    end
+  end
+
+  describe '#open_connection!' do
+    it 'sets the #connection to #open_connection' do
+      connection = double('connection').as_null_object
+
+      expect(broker).to receive(:open_connection).and_return(connection)
+
+      broker.open_connection!
+
+      expect(broker.connection).to eq(connection)
+    end
   end
 
   describe '#open_channel', rabbitmq: true do
@@ -87,6 +107,11 @@ describe Hutch::Broker do
 
       it(nil, adapter: :bunny)      { is_expected.to be_a Bunny::Channel }
       it(nil, adapter: :march_hare) { is_expected.to be_a MarchHare::Channel }
+    end
+
+    it 'does not set #channel' do
+      broker.open_channel
+      expect(broker.channel).to be_nil
     end
 
     context 'with channel_prefetch set' do
@@ -120,6 +145,18 @@ describe Hutch::Broker do
     end
   end
 
+  describe '#open_channel!' do
+    it 'sets the #channel to #open_channel' do
+      channel = double('channel').as_null_object
+
+      expect(broker).to receive(:open_channel).and_return(channel)
+
+      broker.open_channel!
+
+      expect(broker.channel).to eq(channel)
+    end
+  end
+
   describe '#declare_exchange' do
     before do
       broker.open_connection!
@@ -132,6 +169,23 @@ describe Hutch::Broker do
 
       it(nil, adapter: :bunny)      { is_expected.to be_a Bunny::Exchange }
       it(nil, adapter: :march_hare) { is_expected.to be_a MarchHare::Exchange }
+    end
+
+    it 'does not set #exchange' do
+      broker.declare_exchange
+      expect(broker.exchange).to be_nil
+    end
+  end
+
+  describe '#declare_exchange!' do
+    it 'sets the #exchange to #declare_exchange' do
+      exchange = double('exchange').as_null_object
+
+      expect(broker).to receive(:declare_exchange).and_return(exchange)
+
+      broker.declare_exchange!
+
+      expect(broker.exchange).to eq(exchange)
     end
   end
 

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -93,7 +93,7 @@ describe Hutch::Broker do
       before { config[:mq_host] = 'notarealhost' }
       let(:set_up_amqp_connection) { ->{ broker.set_up_amqp_connection } }
 
-      specify { expect(set_up_amqp_connection).to raise_error }
+      specify { expect(set_up_amqp_connection).to raise_error(StandardError) }
     end
 
     context 'with channel_prefetch set' do
@@ -149,7 +149,7 @@ describe Hutch::Broker do
       after  { broker.disconnect }
       let(:set_up_api_connection) { ->{ broker.set_up_api_connection } }
 
-      specify { expect(set_up_api_connection).to raise_error }
+      specify { expect(set_up_api_connection).to raise_error(StandardError) }
     end
   end
 


### PR DESCRIPTION
If the Hutch::Broker is changed like this, one could easily modify it in a way that will resolve #191 e.g.

``` ruby
# Pseudo code I have not tested it :)

class CustomBroker < Hutch::Broker
  def exchange
    return Thread.current[:exchange] if Thread.current[:exchange] 
    declare_exchange!
  end

  def declare_exchange!(ch = open_channel)
    Thread.current[:exchange] = declare_exchange(ch)
  end

  def disconnect
    Thread.list.each { |t| t[:exchange] = nil if t[:exchange] }
    super
  end
end

def Hutch.connect(options = {}, config = Hutch::Config)
  unless connected?
    @broker = CustomBroker.new(config)
    @broker.connect(options)
  end
end
```

follow-up of #194 
see issue #191