### PR TITLE
Addresses some code duplication and tightens up tests in Hutch::CLI

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -109,14 +109,16 @@ module Hutch
           Hutch::Config.mq_tls = tls
         end
 
-        opts.on('--mq-tls-cert FILE', 'Certificate  for TLS client verification') do |file|
-          abort "Certificate file '#{file}' not found" unless File.exists?(file)
-          Hutch::Config.mq_tls_cert = file
+        opts.on('--mq-tls-cert FILE', 'Certificate for TLS client verification') do |file|
+          abort_without_file(file, 'Certificate file') do
+            Hutch::Config.mq_tls_cert = file
+          end
         end
 
         opts.on('--mq-tls-key FILE', 'Private key for TLS client verification') do |file|
-          abort "Private key file '#{file}' not found" unless File.exists?(file)
-          Hutch::Config.mq_tls_key = file
+          abort_without_file(file, 'Private key file') do
+            Hutch::Config.mq_tls_key = file
+          end
         end
 
         opts.on('--mq-exchange EXCHANGE',
@@ -154,7 +156,7 @@ module Hutch
           begin
             File.open(file) { |fp| Hutch::Config.load_from_file(fp) }
           rescue Errno::ENOENT
-            abort "Config file '#{file}' not found"
+            abort_with_message("Config file '#{file}' not found")
           end
         end
 
@@ -204,5 +206,16 @@ module Hutch
       File.open(pidfile, 'w') { |f| f.puts ::Process.pid }
     end
 
+    private
+
+    def abort_without_file(file, file_description, &block)
+      abort_with_message("#{file_description} '#{file}' not found") unless File.exists?(file)
+
+      yield
+    end
+
+    def abort_with_message(message)
+      abort message
+    end
   end
 end

--- a/spec/hutch/cli_spec.rb
+++ b/spec/hutch/cli_spec.rb
@@ -13,7 +13,7 @@ describe Hutch::CLI do
         it "bails" do
           expect {
             cli.parse_options(["--config=#{file}"])
-          }.to raise_error SystemExit
+          }.to raise_error SystemExit, "Config file '/path/to/nonexistant/file' not found"
         end
       end
 
@@ -37,7 +37,7 @@ describe Hutch::CLI do
         it "bails" do
           expect {
             cli.parse_options(["--mq-tls-key=#{file}"])
-          }.to raise_error SystemExit
+          }.to raise_error SystemExit, "Private key file '/path/to/nonexistant/file' not found"
         end
       end
 
@@ -61,7 +61,7 @@ describe Hutch::CLI do
         it "bails" do
           expect {
             cli.parse_options(["--mq-tls-cert=#{file}"])
-          }.to raise_error SystemExit
+          }.to raise_error SystemExit, "Certificate file '/path/to/nonexistant/file' not found"
         end
       end
 


### PR DESCRIPTION
  - Consolidates some code in the CLI around aborting when
    required files don't exist
  - Tests the messaging when CLI encounters SystemExit