### PR TITLE
allow additional worker setup

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -85,7 +85,7 @@ module Hutch
     # gracefully (with a SIGQUIT, SIGTERM or SIGINT).
     def start_work_loop
       Hutch.connect
-      @worker = Hutch::Worker.new(Hutch.broker, Hutch.consumers)
+      @worker = Hutch::Worker.new(Hutch.broker, Hutch::Config[:setup_procs])
       @worker.run
       :success
     rescue ConnectionError, AuthenticationError, WorkerSetupError => ex

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -1,4 +1,5 @@
 require 'hutch/error_handlers/logger'
+require 'hutch/setup/queues'
 require 'erb'
 require 'logger'
 
@@ -62,6 +63,7 @@ module Hutch
         consumer_pool_abort_on_exception: false,
 
         serializer: Hutch::Serializers::JSON,
+        setup_procs: [ Hutch::Setup::Queues ]
       }.merge(params)
     end
 

--- a/lib/hutch/message_handler.rb
+++ b/lib/hutch/message_handler.rb
@@ -1,0 +1,60 @@
+require 'hutch/message'
+
+module Hutch
+  class MessageHandler
+    include Logging
+
+    def self.call
+      new(Hutch.broker)
+    end
+
+    def initialize(broker)
+      self.broker = broker
+    end
+
+    # Called internally when a new messages comes in from RabbitMQ. Responsible
+    # for wrapping up the message and passing it to the consumer.
+    def call(consumer, delivery_info, properties, payload)
+      serializer = consumer.get_serializer || Hutch::Config[:serializer]
+      logger.debug {
+        spec   = serializer.binary? ? "#{payload.bytesize} bytes" : "#{payload}"
+        "message(#{properties.message_id || '-'}): " +
+          "routing key: #{delivery_info.routing_key}, " +
+          "consumer: #{consumer}, " +
+          "payload: #{spec}"
+      }
+
+      message = Message.new(delivery_info, properties, payload, serializer)
+      consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = broker, delivery_info }
+      with_tracing(consumer_instance).handle(message)
+      broker.ack(delivery_info.delivery_tag)
+    rescue => ex
+      acknowledge_error(delivery_info, properties, broker, ex)
+      handle_error(properties.message_id, payload, consumer, ex)
+    end
+
+    attr_accessor :broker
+
+    def with_tracing(klass)
+      Hutch::Config[:tracer].new(klass)
+    end
+
+    def handle_error(message_id, payload, consumer, ex)
+      Hutch::Config[:error_handlers].each do |backend|
+        backend.handle(message_id, payload, consumer, ex)
+      end
+    end
+
+    def acknowledge_error(delivery_info, properties, broker, ex)
+      acks = error_acknowledgements +
+        [Hutch::Acknowledgements::NackOnAllFailures.new]
+      acks.find do |backend|
+        backend.handle(delivery_info, properties, broker, ex)
+      end
+    end
+
+    def error_acknowledgements
+      Hutch::Config[:error_acknowledgements]
+    end
+  end
+end

--- a/lib/hutch/setup/queues.rb
+++ b/lib/hutch/setup/queues.rb
@@ -1,0 +1,41 @@
+require 'hutch/logging'
+require 'hutch/config'
+require 'hutch/acknowledgements/nack_on_all_failures'
+
+module Hutch
+  module Setup
+    class Queues
+      include Logging
+
+      def self.call
+        new(Hutch.broker, Hutch.consumers).call
+      end
+
+      def initialize(broker, consumers)
+        self.broker = broker
+        self.consumers = consumers
+      end
+
+      def call
+        logger.info 'setting up queues'
+        consumers.each { |consumer| setup_queue(consumer) }
+      end
+
+      private
+
+      attr_accessor :broker, :consumers
+
+      # Bind a consumer's routing keys to its queue, and set up a subscription to
+      # receive messages sent to the queue.
+      def setup_queue(consumer)
+        queue = broker.queue(consumer.get_queue_name, consumer.get_arguments)
+        broker.bind_queue(queue, consumer.routing_keys)
+
+        queue.subscribe(manual_ack: true) do |*args|
+          delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
+          MessageHandler.call(consumer, delivery_info, properties, payload)
+        end
+      end
+    end
+  end
+end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -10,16 +10,16 @@ module Hutch
 
     SHUTDOWN_SIGNALS = %w(QUIT TERM INT)
 
-    def initialize(broker, consumers)
-      @broker        = broker
-      self.consumers = consumers
+    def initialize(broker, setup_procs)
+      @broker          = broker
+      self.setup_procs = setup_procs
     end
 
     # Run the main event loop. The consumers will be set up with queues, and
     # process the messages in their respective queues indefinitely. This method
     # never returns.
     def run
-      setup_queues
+      setup_procs.each(&:call)
 
       # Set up signal handlers for graceful shutdown
       register_signal_handlers
@@ -82,74 +82,6 @@ module Hutch
         sleep(interval)
         false
       end
-    end
-
-    # Set up the queues for each of the worker's consumers.
-    def setup_queues
-      logger.info 'setting up queues'
-      @consumers.each { |consumer| setup_queue(consumer) }
-    end
-
-    # Bind a consumer's routing keys to its queue, and set up a subscription to
-    # receive messages sent to the queue.
-    def setup_queue(consumer)
-      queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
-      @broker.bind_queue(queue, consumer.routing_keys)
-
-      queue.subscribe(manual_ack: true) do |*args|
-        delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
-        handle_message(consumer, delivery_info, properties, payload)
-      end
-    end
-
-    # Called internally when a new messages comes in from RabbitMQ. Responsible
-    # for wrapping up the message and passing it to the consumer.
-    def handle_message(consumer, delivery_info, properties, payload)
-      serializer = consumer.get_serializer || Hutch::Config[:serializer]
-      logger.debug {
-        spec   = serializer.binary? ? "#{payload.bytesize} bytes" : "#{payload}"
-        "message(#{properties.message_id || '-'}): " +
-        "routing key: #{delivery_info.routing_key}, " +
-        "consumer: #{consumer}, " +
-        "payload: #{spec}"
-      }
-
-      message = Message.new(delivery_info, properties, payload, serializer)
-      consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = @broker, delivery_info }
-      with_tracing(consumer_instance).handle(message)
-      @broker.ack(delivery_info.delivery_tag)
-    rescue => ex
-      acknowledge_error(delivery_info, properties, @broker, ex)
-      handle_error(properties.message_id, payload, consumer, ex)
-    end
-
-    def with_tracing(klass)
-      Hutch::Config[:tracer].new(klass)
-    end
-
-    def handle_error(message_id, payload, consumer, ex)
-      Hutch::Config[:error_handlers].each do |backend|
-        backend.handle(message_id, payload, consumer, ex)
-      end
-    end
-
-    def acknowledge_error(delivery_info, properties, broker, ex)
-      acks = error_acknowledgements +
-        [Hutch::Acknowledgements::NackOnAllFailures.new]
-      acks.find do |backend|
-        backend.handle(delivery_info, properties, broker, ex)
-      end
-    end
-
-    def consumers=(val)
-      if val.empty?
-        logger.warn "no consumer loaded, ensure there's no configuration issue"
-      end
-      @consumers = val
-    end
-
-    def error_acknowledgements
-      Hutch::Config[:error_acknowledgements]
     end
 
     private

--- a/spec/factory_helper.rb
+++ b/spec/factory_helper.rb
@@ -1,0 +1,13 @@
+def build_consumer
+  @consumer_inc ||= "0"
+  @consumer_inc = @consumer_inc.next
+  double('Consumer',
+         routing_keys: %w( a b c ),
+         get_queue_name: 'consumer' + @consumer_inc,
+         get_arguments: {},
+         get_serializer: nil)
+end
+
+def build_queue
+  instance_double('Bunny::Queue')
+end

--- a/spec/hutch/setup/queues_spec.rb
+++ b/spec/hutch/setup/queues_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'factory_helper'
+require 'hutch/setup/queues'
+
+describe Hutch::Setup::Queues do
+  let(:broker) { instance_double("Hutch::Broker") }
+  let(:consumers) { Array.new(2) { build_consumer } }
+  subject(:setup_performer) { described_class.new(broker, consumers) }
+
+  describe '#call' do
+    it 'sets up queues for each of the consumers' do
+      consumers.each do |consumer|
+        queue = build_queue
+        expect(broker).to receive(:queue)
+          .with(consumer.get_queue_name, consumer.get_arguments)
+          .and_return(queue)
+        expect(broker).to receive(:bind_queue)
+          .with(queue, consumer.routing_keys)
+        expect(queue).to receive(:subscribe).with(manual_ack: true)
+      end
+
+      setup_performer.call
+    end
+  end
+end


### PR DESCRIPTION
### Why
I needed to create a per-queue dead letter handling system and, judging by some of the old issues, Hutch would prefer to stay out of that business. So I needed a way to hook into Hutch during worker setup to do the dead letter stuff outside of Hutch.

### What
- Added an array of objects that will be called at the start of `worker#run` to Hutch::Config
- Refactored out the queue setup stuff to clear up the worker. it is now the first item of setup_procs.

### Usage
```
>> Hutch::Config.setup_procs << Proc.new { puts "HELLO WORLD" }

>> Hutch::Config.setup_procs << other_object_that_responds_to_call
```

### Other stuff
This isn't quite in a great state. The MessageHandler class is basically a dump of functionality where I realized I should probably open a PR and see if this had any legs before I put too much time into the refactor. If this basic idea is good I would be happy to polish this up more.

I also have another branch that builds on the worker cleanup in this and gets worker down to 51 fully tested lines. [worker.rb](https://github.com/CasperSleep/hutch/blob/worker_refactor/lib/hutch/worker.rb) [worker_spec.rb](https://github.com/CasperSleep/hutch/blob/worker_refactor/spec/hutch/worker_spec.rb)