### PR TITLE
WIP: Feature ENV config keys

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -70,7 +70,7 @@ module Hutch
       }
     end
 
-    def self.clear!
+    def self.reset!
       @config = default_config
     end
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -8,6 +8,33 @@ module Hutch
   module Config
     require 'yaml'
 
+    STRING_SETTINGS = %w(mq_host
+                         mq_exchange
+                         mq_vhost
+                         mq_username
+                         mq_password
+                         mq_api_host)
+
+    INTEGER_SETTINGS = %w(mq_port
+                          mq_api_port
+                          heartbeat
+                          channel_prefetch
+                          connection_timeout
+                          read_timeout
+                          write_timeout
+                          graceful_exit_timeout
+                          consumer_pool_size)
+
+    BOOLEAN_SETTINGS = %w(mq_tls
+                          mq_verify_peer
+                          mq_api_ssl
+                          autoload_rails
+                          daemonize
+                          publisher_confirms
+                          force_publisher_confirms
+                          enable_http_api_use
+                          consumer_pool_abort_on_exception)
+
     def self.initialize(params = {})
       @config = default_config.merge(params)
     end

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -16,7 +16,7 @@ module Hutch
       {
         mq_host: '127.0.0.1',
         mq_port: 5672,
-        mq_exchange: 'hutch', # TODO: should this be required?
+        mq_exchange: 'hutch',  # TODO: should this be required?
         mq_exchange_options: {},
         mq_vhost: '/',
         mq_tls: false,

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -9,10 +9,14 @@ module Hutch
     require 'yaml'
 
     def self.initialize(params = {})
-      @config = {
+      @config = default_config.merge(params)
+    end
+
+    def self.default_config
+      {
         mq_host: '127.0.0.1',
         mq_port: 5672,
-        mq_exchange: 'hutch',  # TODO: should this be required?
+        mq_exchange: 'hutch', # TODO: should this be required?
         mq_exchange_options: {},
         mq_vhost: '/',
         mq_tls: false,
@@ -63,7 +67,11 @@ module Hutch
         consumer_pool_abort_on_exception: false,
 
         serializer: Hutch::Serializers::JSON,
-      }.merge(params)
+      }
+    end
+
+    def self.clear!
+      @config = default_config
     end
 
     def self.get(attr)

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -3,7 +3,7 @@ require 'tempfile'
 
 describe Hutch::Config do
   let(:new_value) { 'not-localhost' }
-  
+
   before do
     Hutch::Config.clear!
   end
@@ -137,7 +137,7 @@ describe Hutch::Config do
         <<-YAML
 mq_host: 'localhost'
 mq_username: '<%= "calvin" %>'
-        YAML
+YAML
       end
       it 'loads in the config data' do
         Hutch::Config.load_from_file(file)

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -5,7 +5,7 @@ describe Hutch::Config do
   let(:new_value) { 'not-localhost' }
 
   before do
-    Hutch::Config.clear!
+    Hutch::Config.reset!
   end
 
   describe '.get' do

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -96,26 +96,21 @@ describe Hutch::Config do
         expect(Hutch::Config.mq_username).to eq username
       end
     end
-  end
 
-  describe '.load_from_file' do
-    let(:host) { 'localhost' }
-    let(:username) { 'calvin' }
-    let(:file) do
-      Tempfile.new('configs.yaml').tap do |t|
-        t.write(config_contents)
-        t.rewind
+    context 'when using ERB' do
+      let(:host) { 'localhost' }
+      let(:file) do
+        Tempfile.new('configs.yaml').tap do |t|
+          t.write(config_contents)
+          t.rewind
+        end
       end
-    end
-
-    context 'when using ERb' do
       let(:config_contents) do
         <<-YAML
 mq_host: 'localhost'
 mq_username: '<%= "calvin" %>'
-YAML
+        YAML
       end
-
       it 'loads in the config data' do
         Hutch::Config.load_from_file(file)
         expect(Hutch::Config.mq_host).to eq host

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -3,6 +3,10 @@ require 'tempfile'
 
 describe Hutch::Config do
   let(:new_value) { 'not-localhost' }
+  
+  before do
+    Hutch::Config.clear!
+  end
 
   describe '.get' do
     context 'for valid attributes' do
@@ -51,6 +55,30 @@ describe Hutch::Config do
     context 'for an invalid attribute' do
       let(:invalid_getter) { ->{ Hutch::Config.invalid_attr } }
       specify { expect(invalid_getter).to raise_error NoMethodError }
+    end
+
+    context 'for an ENV-overriden value attribute' do
+      around do |example|
+        ENV['HUTCH_MQ_HOST'] = 'example.com'
+        ENV['HUTCH_MQ_PORT'] = '10001'
+        ENV['HUTCH_MQ_TLS'] = 'true'
+        example.run
+        ENV.delete('HUTCH_MQ_HOST')
+        ENV.delete('HUTCH_MQ_PORT')
+        ENV.delete('HUTCH_MQ_TLS')
+      end
+
+      it 'returns the override' do
+        expect(Hutch::Config.mq_host).to eq 'example.com'
+      end
+
+      it 'returns the override for integers' do
+        expect(Hutch::Config.mq_port).to eq 10001
+      end
+
+      it 'returns the override for booleans' do
+        expect(Hutch::Config.mq_tls).to eq true
+      end
     end
   end
 


### PR DESCRIPTION
In order to create #208, this is a work-in-progress PR with a TODO list.

## TODO

- [x] lists of typed config options for String, Number and Boolean (Example: `string_config_options = %w(mq_host mq_exchange et_cetera)`)
- [ ] an implementation
- [ ] more features?