### PR TITLE
Silence Bunny Logger in tests

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -121,11 +121,5 @@ module Hutch
         get(attr)
       end
     end
-
-    private
-
-    def deep_copy(obj)
-      Marshal.load(Marshal.dump(obj))
-    end
   end
 end

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'hutch/broker'
 
 describe Hutch::Broker do
-  let(:config) { deep_copy(Hutch::Config.user_config) }
+  let(:config) { Hutch::Config.initialize(client_logger: Hutch::Logging.logger) }
   subject(:broker) { Hutch::Broker.new(config) }
 
   describe '#connect' do
@@ -74,7 +74,7 @@ describe Hutch::Broker do
 
     context 'when given invalid details' do
       before { config[:mq_host] = 'notarealhost' }
-      it { expect { broker.open_connection }.to raise_error(StandardError) }
+      it { expect { broker.open_connection }.to raise_error(Hutch::ConnectionError) }
     end
 
     it 'does not set #connection' do

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -74,7 +74,7 @@ describe Hutch::Broker do
 
     context 'when given invalid details' do
       before { config[:mq_host] = 'notarealhost' }
-      it { expect { broker.open_connection }.to raise_error(Hutch::ConnectionError) }
+      it { expect { broker.open_connection }.to raise_error(StandardError) }
     end
 
     it 'does not set #connection' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,3 @@ ensure
     Object.send(:remove_const, constant)
   end
 end
-
-def deep_copy(obj)
-  Marshal.load(Marshal.dump(obj))
-end


### PR DESCRIPTION
Set client_logger in broker_spec to log to /dev/null.

I also got rid of deep_copy. The config should just be the default,
which means a call to Hutch::Logger.initialize will suffice.

Finally, I made the expected error in broker_spec more specific.