### PR TITLE
Validate partial doubles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem "honeybadger"
   gem "coveralls", require: false
   gem "newrelic_rpm"
-  gem "airbrake"
+  gem "airbrake", "~> 4.0"
 end
 
 group :development, :darwin do

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -1,4 +1,6 @@
 require 'hutch/error_handlers/logger'
+require 'hutch/tracers'
+require 'hutch/serializers/json'
 require 'erb'
 require 'logger'
 
@@ -39,7 +41,7 @@ module Hutch
 
     def self.initialize(params = {})
       @config = default_config
-      @config.merge(env_based_config).merge(params)
+      @config.merge!(env_based_config).merge!(params)
       define_methods
       @config
     end

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -129,10 +129,6 @@ module Hutch
       ALL_KEYS.select { |attr| ENV.key?(key_for(attr)) }
     end
 
-    def self.reset!
-      @config = initialize
-    end
-
     def self.get(attr)
       check_attr(attr)
       user_config[attr]

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -38,12 +38,13 @@ module Hutch
     ALL_KEYS = (BOOL_KEYS + NUMBER_KEYS + STRING_KEYS).map(&:to_sym).freeze
 
     def self.initialize(params = {})
-      @config = defaults.merge(params)
+      @config = default_config
+      @config.merge(env_based_config).merge(params)
       define_methods
       @config
     end
 
-    def self.defaults
+    def self.default_config
       {
         mq_host: '127.0.0.1',
         mq_port: 5672,
@@ -163,7 +164,7 @@ module Hutch
     end
 
     def self.check_attr(attr)
-      unless default_config.key?(attr)
+      unless user_config.key?(attr)
         raise UnknownAttributeError, "#{attr.inspect} is not a valid config attribute"
       end
     end

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -5,7 +5,7 @@ describe Hutch::Config do
   let(:new_value) { 'not-localhost' }
 
   before do
-    Hutch::Config.reset!
+    Hutch::Config.initialize
   end
 
   describe '.get' do

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -32,7 +32,6 @@ describe Hutch::Worker do
 
   describe '#setup_queue' do
     let(:queue) { double('Queue', bind: nil, subscribe: nil) }
-    before { allow(worker).to receive_messages(consumer_queue: queue) }
     before { allow(broker).to receive_messages(queue: queue, bind_queue: nil) }
 
     it 'creates a queue' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ RSpec.configure do |config|
   else
     config.filter_run_excluding adapter: :march_hare
   end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
 end
 
 # Constants (classes, etc) defined within a block passed to this method


### PR DESCRIPTION
RSpec allows you to validate that mocked methods exist on classes, so I thought I would turn it on and fix what popped up.