### PR TITLE
WIP: YARD settings, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 .ruby-gemset
 .idea
 coverage
+.yardoc
+doc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+-m markdown
+

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -42,7 +42,7 @@ module Hutch
       end
     end
 
-    # Register handlers for SIG{QUIT,TERM,INT} to shut down the worker
+    # Register handlers for SIGQUIT, SIGTERM, SIGINT to shut down the worker
     # gracefully. Forceful shutdowns are very bad!
     def register_signal_handlers
       Thread.main[:signal_queue] = []


### PR DESCRIPTION
This PR introduces config for [Yardoc](http://yardoc.org/), a system to render API docs.

  - ignore rendered output `doc/` folder (we can publish it just after we render it)
  - decide to use Markdown to style comments
  - avoid a yardoc warning by expanding something that looked like an internal link to it

**Update**: Since Open Source is amazing, the YARD output is already automatically rendered by http://www.rubydoc.info/gems/hutch - so we can merely author prettier docs for it.