### PR TITLE
Docs: Hutch::Config

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
+--title "Hutch API docs"
 -
 README.md
 

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
+-e "./lib/yard-settings/yard-settings.rb"
 --title "Hutch API docs"
 -
 README.md

--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,4 @@
--e "./lib/yard-settings/yard-settings.rb"
+--load "./lib/yard-settings/yard-settings.rb"
 --title "Hutch API docs"
 -
 README.md

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,3 @@
--m markdown
+-
+README.md
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ a [Logger object](http://ruby-doc.org/stdlib-2.1.2/libdoc/logger/rdoc/Logger.htm
 class FailedPaymentConsumer
   include Hutch::Consumer
   consume 'gc.ps.payment.failed'
-  
+
   def process(message)
     logger.info "Marking payment #{message[:id]} as failed"
     mark_payment_as_failed(message[:id])

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,11 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = %w(--color --format doc)
 end
 
-task :default => :spec
+task default: :spec
+
+#
+# Re-generate API docs
+#
+require 'yard'
+require 'yard/rake/yardoc_task'
+YARD::Rake::YardocTask.new

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'yard', '~> 0.8'
+  gem.add_development_dependency 'redcarpet', '> 0'
+  gem.add_development_dependency 'github-markup', '> 0'
 
   gem.name = 'hutch'
   gem.summary = 'Easy inter-service communication using RabbitMQ.'

--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -14,7 +14,6 @@ require 'hutch/exceptions'
 require 'hutch/tracers'
 
 module Hutch
-
   def self.register_consumer(consumer)
     self.consumers << consumer
   end
@@ -35,11 +34,16 @@ module Hutch
     @global_properties ||= {}
   end
 
+  # Connects to broker, if not yet connected.
+  #
+  # @param options [Hash] Connection options
+  # @param config [Hash] Configuration
+  # @option options [Boolean] :enable_http_api_use
   def self.connect(options = {}, config = Hutch::Config)
-    unless connected?
-      @broker = Hutch::Broker.new(config)
-      @broker.connect(options)
-    end
+    return if connected?
+
+    @broker = Hutch::Broker.new(config)
+    @broker.connect(options)
   end
 
   def self.disconnect
@@ -50,10 +54,9 @@ module Hutch
     @broker
   end
 
+  # @return [Boolean]
   def self.connected?
-    return false unless broker
-    return false unless broker.connection
-    broker.connection.open?
+    broker && broker.connection && broker.connection.open?
   end
 
   def self.publish(*args)

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -11,10 +11,20 @@ module Hutch
 
     attr_accessor :connection, :channel, :exchange, :api_client
 
+    # @param config [nil,Hash] Configuration override
     def initialize(config = nil)
       @config = config || Hutch::Config
     end
 
+    # Connect to broker
+    #
+    # @example
+    #   Hutch::Broker.new.connect(enable_http_api_use: true) do
+    #     # will disconnect after this block
+    #   end
+    #
+    # @param [Hash] options The options to connect with
+    # @option options [Boolean] :enable_http_api_use
     def connect(options = {})
       @options = options
       set_up_amqp_connection
@@ -49,9 +59,10 @@ module Hutch
       @api_client = nil
     end
 
-    # Connect to RabbitMQ via AMQP. This sets up the main connection and
-    # channel we use for talking to RabbitMQ. It also ensures the existance of
-    # the exchange we'll be using.
+    # Connect to RabbitMQ via AMQP
+    #
+    # This sets up the main connection and channel we use for talking to
+    # RabbitMQ. It also ensures the existence of the exchange we'll be using.
     def set_up_amqp_connection
       open_connection!
       open_channel!
@@ -237,6 +248,7 @@ module Hutch
       channel.wait_for_confirms
     end
 
+    # @return [Boolean] True if channel is set up to use publisher confirmations.
     def using_publisher_confirmations?
       channel.using_publisher_confirmations?
     end
@@ -351,6 +363,5 @@ module Hutch
     def consumer_pool_abort_on_exception
       @config[:consumer_pool_abort_on_exception]
     end
-
   end
 end

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -15,29 +15,29 @@ module Hutch
   #   HUTCH_PUBLISHER_CONFIRMS=false hutch
   module Config
     require 'yaml'
-    STRING_KEYS = Set.new
-    NUMBER_KEYS = Set.new
-    BOOL_KEYS = Set.new
+    @string_keys = Set.new
+    @number_keys = Set.new
+    @boolean_keys = Set.new
     @settings_defaults = {}
 
     # Define a String user setting
     # @!visibility private
     def self.string_setting(name, default_value)
-      STRING_KEYS << name
+      @string_keys << name
       @settings_defaults[name] = default_value
     end
 
     # Define a Number user setting
     # @!visibility private
     def self.number_setting(name, default_value)
-      NUMBER_KEYS << name
+      @number_keys << name
       @settings_defaults[name] = default_value
     end
 
     # Define a Boolean user setting
     # @!visibility private
     def self.boolean_setting(name, default_value)
-      BOOL_KEYS << name
+      @boolean_keys << name
       @settings_defaults[name] = default_value
     end
 
@@ -90,12 +90,18 @@ module Hutch
     # Enables publisher confirms. Leaves it up to the app how they are tracked
     # (e.g. using Hutch::Broker#confirm_select callback or Hutch::Broker#wait_for_confirms)
     boolean_setting :publisher_confirms, false
+    # Enables publisher confirms, forces Hutch::Broker#wait_for_confirms for
+    # every publish. **This is the safest option which also offers the 
+    # lowest throughput**.
     boolean_setting :force_publisher_confirms, false
+    # Enable use of RabbitMQ HTTP API
     boolean_setting :enable_http_api_use, true
+    # Defines whether Bunny's consumer work pool threads should abort
+    # on exception. The option is ignored on JRuby.
     boolean_setting :consumer_pool_abort_on_exception, false
 
     # Set of all setting keys
-    ALL_KEYS = BOOL_KEYS + NUMBER_KEYS + STRING_KEYS
+    ALL_KEYS = @boolean_keys + @number_keys + @string_keys
 
     def self.initialize(params = {})
       @config = default_config.merge(env_based_config).merge(params)
@@ -165,7 +171,7 @@ module Hutch
     end
 
     def self.is_bool(attr)
-      BOOL_KEYS.include?(attr)
+      @boolean_keys.include?(attr)
     end
 
     def self.to_bool(value)
@@ -173,7 +179,7 @@ module Hutch
     end
 
     def self.is_num(attr)
-      NUMBER_KEYS.include?(attr)
+      @number_keys.include?(attr)
     end
 
     def self.set(attr, value)

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -5,9 +5,18 @@ require 'logger'
 module Hutch
   class UnknownAttributeError < StandardError; end
 
+  # Configuration settings, available everywhere
+  #
+  # There are defaults, which can be overridden by ENV variables prefixed by
+  # <tt>HUTCH_</tt>, and each of these can be overridden using the {.set}
+  # method.
+  #
+  # @example Configuring on the command-line
+  #   HUTCH_PUBLISHER_CONFIRMS=false hutch
   module Config
     require 'yaml'
 
+    # Settings which accept a String
     STRING_KEYS = %w(mq_host
                      mq_exchange
                      mq_vhost
@@ -15,6 +24,7 @@ module Hutch
                      mq_password
                      mq_api_host).freeze
 
+    # Settings which accept a Number
     NUMBER_KEYS = %w(mq_port
                      mq_api_port
                      heartbeat
@@ -25,6 +35,7 @@ module Hutch
                      graceful_exit_timeout
                      consumer_pool_size).freeze
 
+    # Settings which accept a Boolean
     BOOL_KEYS = %w(mq_tls
                    mq_verify_peer
                    mq_api_ssl
@@ -35,12 +46,16 @@ module Hutch
                    enable_http_api_use
                    consumer_pool_abort_on_exception).freeze
 
+    # Convenience collection of all setting keys
     ALL_KEYS = (BOOL_KEYS + NUMBER_KEYS + STRING_KEYS).map(&:to_sym).freeze
 
     def self.initialize(params = {})
       @config = default_config.merge(env_based_config).merge(params)
     end
 
+    # Default settings
+    #
+    # @return [Hash]
     def self.default_config
       {
         mq_host: '127.0.0.1',
@@ -99,7 +114,7 @@ module Hutch
       }
     end
 
-    # Override defaults with ENV variables which begin with HUTCH_
+    # Override defaults with ENV variables which begin with <tt>HUTCH_</tt>
     #
     # @return [Hash]
     def self.env_based_config

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -21,20 +21,23 @@ module Hutch
 
     # Define a String user setting
     # @!visibility private
-    def self.string_setting(name, _default_value)
+    def self.string_setting(name, default_value)
       STRING_KEYS << name
+      default_value
     end
 
     # Define a Number user setting
     # @!visibility private
-    def self.number_setting(name, _default_value)
+    def self.number_setting(name, default_value)
       NUMBER_KEYS << name
+      default_value
     end
 
     # Define a Boolean user setting
     # @!visibility private
-    def self.boolean_setting(name, _default_value)
+    def self.boolean_setting(name, default_value)
       BOOL_KEYS << name
+      default_value
     end
 
     # RabbitMQ hostname

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -20,46 +20,49 @@ module Hutch
     BOOL_KEYS = Set.new
 
     # Define a String user setting
-    def self.string_setting(name)
+    # @!visibility private
+    def self.string_setting(name, _default_value)
       STRING_KEYS << name
     end
 
     # Define a Number user setting
-    def self.number_setting(name)
+    # @!visibility private
+    def self.number_setting(name, _default_value)
       NUMBER_KEYS << name
     end
 
     # Define a Boolean user setting
-    def self.boolean_setting(name)
+    # @!visibility private
+    def self.boolean_setting(name, _default_value)
       BOOL_KEYS << name
     end
 
-    string_setting :mq_host
-    string_setting :mq_exchange
-    string_setting :mq_vhost
-    string_setting :mq_username
-    string_setting :mq_password
-    string_setting :mq_api_host
+    string_setting :mq_host, '127.0.0.1'
+    string_setting :mq_exchange, 'hutch'
+    string_setting :mq_vhost, '/'
+    string_setting :mq_username, 'guest'
+    string_setting :mq_password, 'guest'
+    string_setting :mq_api_host, '127.0.0.1'
 
-    number_setting :mq_port
-    number_setting :mq_api_port
-    number_setting :heartbeat
-    number_setting :channel_prefetch
-    number_setting :connection_timeout
-    number_setting :read_timeout
-    number_setting :write_timeout
-    number_setting :graceful_exit_timeout
-    number_setting :consumer_pool_size
+    number_setting :mq_port, 5672
+    number_setting :mq_api_port, 15672
+    number_setting :heartbeat, 30
+    number_setting :channel_prefetch, 0
+    number_setting :connection_timeout, 11
+    number_setting :read_timeout, 11
+    number_setting :write_timeout, 11
+    number_setting :graceful_exit_timeout, 11
+    number_setting :consumer_pool_size, 1
 
-    boolean_setting :mq_tls
-    boolean_setting :mq_verify_peer
-    boolean_setting :mq_api_ssl
-    boolean_setting :autoload_rails
-    boolean_setting :daemonise
-    boolean_setting :publisher_confirms
-    boolean_setting :force_publisher_confirms
-    boolean_setting :enable_http_api_use
-    boolean_setting :consumer_pool_abort_on_exception
+    boolean_setting :mq_tls, false
+    boolean_setting :mq_verify_peer, true
+    boolean_setting :mq_api_ssl, false
+    boolean_setting :autoload_rails, true
+    boolean_setting :daemonise, false
+    boolean_setting :publisher_confirms, false
+    boolean_setting :force_publisher_confirms, false
+    boolean_setting :enable_http_api_use, true
+    boolean_setting :consumer_pool_abort_on_exception, false
 
     # Set of all setting keys
     ALL_KEYS = BOOL_KEYS + NUMBER_KEYS + STRING_KEYS

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -18,26 +18,27 @@ module Hutch
     STRING_KEYS = Set.new
     NUMBER_KEYS = Set.new
     BOOL_KEYS = Set.new
+    @settings_defaults = {}
 
     # Define a String user setting
     # @!visibility private
     def self.string_setting(name, default_value)
       STRING_KEYS << name
-      default_value
+      @settings_defaults[name] = default_value
     end
 
     # Define a Number user setting
     # @!visibility private
     def self.number_setting(name, default_value)
       NUMBER_KEYS << name
-      default_value
+      @settings_defaults[name] = default_value
     end
 
     # Define a Boolean user setting
     # @!visibility private
     def self.boolean_setting(name, default_value)
       BOOL_KEYS << name
-      default_value
+      @settings_defaults[name] = default_value
     end
 
     # RabbitMQ hostname
@@ -104,29 +105,14 @@ module Hutch
     #
     # @return [Hash]
     def self.default_config
-      {
-        mq_host: '127.0.0.1',
-        mq_port: 5672,
-        mq_exchange: 'hutch', # TODO: should this be required?
+      @settings_defaults.merge({
         mq_exchange_options: {},
-        mq_vhost: '/',
-        mq_tls: false,
         mq_tls_cert: nil,
         mq_tls_key: nil,
         mq_tls_ca_certificates: nil,
-        mq_verify_peer: true,
-        mq_username: 'guest',
-        mq_password: 'guest',
-        mq_api_host: '127.0.0.1',
-        mq_api_port: 15672,
-        mq_api_ssl: false,
-        heartbeat: 30,
-        # placeholder, allows specifying connection parameters
-        # as a URI.
         uri: nil,
         log_level: Logger::INFO,
         require_paths: [],
-        autoload_rails: true,
         error_handlers: [Hutch::ErrorHandlers::Logger.new],
         # note that this is not a list, it is a chain of responsibility
         # that will fall back to "nack unconditionally"
@@ -134,31 +120,9 @@ module Hutch
         setup_procs: [],
         tracer: Hutch::Tracers::NullTracer,
         namespace: nil,
-        daemonise: false,
         pidfile: nil,
-        channel_prefetch: 0,
-        # enables publisher confirms, leaves it up to the app
-        # how they are tracked
-        publisher_confirms: false,
-        # like `publisher_confirms` above but also
-        # forces waiting for a confirm for every publish
-        force_publisher_confirms: false,
-        # Heroku needs > 10. MK.
-        connection_timeout: 11,
-        read_timeout: 11,
-        write_timeout: 11,
-        enable_http_api_use: true,
-        # Number of seconds that a running consumer is given
-        # to finish its job when gracefully exiting Hutch, before
-        # it's killed.
-        graceful_exit_timeout: 11,
-        client_logger: nil,
-
-        consumer_pool_size: 1,
-        consumer_pool_abort_on_exception: false,
-
         serializer: Hutch::Serializers::JSON
-      }
+      })
     end
 
     # Override defaults with ENV variables which begin with <tt>HUTCH_</tt>

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -37,15 +37,31 @@ module Hutch
       BOOL_KEYS << name
     end
 
+    # RabbitMQ hostname
     string_setting :mq_host, '127.0.0.1'
+
+    # RabbitMQ Exchange
     string_setting :mq_exchange, 'hutch'
+
+    # RabbitMQ vhost to use
     string_setting :mq_vhost, '/'
+
+    # RabbitMQ username to use. As of RabbitMQ 3.3.0, <tt>guest</tt> can only can connect from localhost.
     string_setting :mq_username, 'guest'
+
+    # RabbitMQ password
     string_setting :mq_password, 'guest'
+
+    # RabbitMQ API Host
     string_setting :mq_api_host, '127.0.0.1'
 
+    # RabbitMQ port
     number_setting :mq_port, 5672
+
+    # RabbitMQ API port
     number_setting :mq_api_port, 15672
+
+    # [RabbitMQ heartbeat timeout](http://rabbitmq.com/heartbeats.html)
     number_setting :heartbeat, 30
     number_setting :channel_prefetch, 0
     number_setting :connection_timeout, 11

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -40,7 +40,7 @@ module Hutch
     # RabbitMQ hostname
     string_setting :mq_host, '127.0.0.1'
 
-    # RabbitMQ Exchange
+    # RabbitMQ Exchange to use for publishing
     string_setting :mq_exchange, 'hutch'
 
     # RabbitMQ vhost to use
@@ -63,18 +63,28 @@ module Hutch
 
     # [RabbitMQ heartbeat timeout](http://rabbitmq.com/heartbeats.html)
     number_setting :heartbeat, 30
+    # The <tt>basic.qos</tt> prefetch value to use. Default: `0`, no limit. See Bunny and RabbitMQ documentation.
     number_setting :channel_prefetch, 0
+    # Bunny's socket open timeout
     number_setting :connection_timeout, 11
+    # Bunny's socket read timeout
     number_setting :read_timeout, 11
+    # Bunny's socket write timeout
     number_setting :write_timeout, 11
+    # FIXME: DOCUMENT THIS
     number_setting :graceful_exit_timeout, 11
+    # 
     number_setting :consumer_pool_size, 1
 
     boolean_setting :mq_tls, false
+    # Should SSL certificate be verified?
     boolean_setting :mq_verify_peer, true
     boolean_setting :mq_api_ssl, false
     boolean_setting :autoload_rails, true
+    # Should the Hutch runner process daemonise?
     boolean_setting :daemonise, false
+    # Enables publisher confirms. Leaves it up to the app how they are tracked
+    # (e.g. using Hutch::Broker#confirm_select callback or Hutch::Broker#wait_for_confirms)
     boolean_setting :publisher_confirms, false
     boolean_setting :force_publisher_confirms, false
     boolean_setting :enable_http_api_use, true

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -15,39 +15,54 @@ module Hutch
   #   HUTCH_PUBLISHER_CONFIRMS=false hutch
   module Config
     require 'yaml'
+    STRING_KEYS = Set.new
+    NUMBER_KEYS = Set.new
+    BOOL_KEYS = Set.new
 
-    # Settings which accept a String
-    STRING_KEYS = %w(mq_host
-                     mq_exchange
-                     mq_vhost
-                     mq_username
-                     mq_password
-                     mq_api_host).freeze
+    # Define a String user setting
+    def self.string_setting(name)
+      STRING_KEYS << name
+    end
 
-    # Settings which accept a Number
-    NUMBER_KEYS = %w(mq_port
-                     mq_api_port
-                     heartbeat
-                     channel_prefetch
-                     connection_timeout
-                     read_timeout
-                     write_timeout
-                     graceful_exit_timeout
-                     consumer_pool_size).freeze
+    # Define a Number user setting
+    def self.number_setting(name)
+      NUMBER_KEYS << name
+    end
 
-    # Settings which accept a Boolean
-    BOOL_KEYS = %w(mq_tls
-                   mq_verify_peer
-                   mq_api_ssl
-                   autoload_rails
-                   daemonise
-                   publisher_confirms
-                   force_publisher_confirms
-                   enable_http_api_use
-                   consumer_pool_abort_on_exception).freeze
+    # Define a Boolean user setting
+    def self.boolean_setting(name)
+      BOOL_KEYS << name
+    end
 
-    # Convenience collection of all setting keys
-    ALL_KEYS = (BOOL_KEYS + NUMBER_KEYS + STRING_KEYS).map(&:to_sym).freeze
+    string_setting :mq_host
+    string_setting :mq_exchange
+    string_setting :mq_vhost
+    string_setting :mq_username
+    string_setting :mq_password
+    string_setting :mq_api_host
+
+    number_setting :mq_port
+    number_setting :mq_api_port
+    number_setting :heartbeat
+    number_setting :channel_prefetch
+    number_setting :connection_timeout
+    number_setting :read_timeout
+    number_setting :write_timeout
+    number_setting :graceful_exit_timeout
+    number_setting :consumer_pool_size
+
+    boolean_setting :mq_tls
+    boolean_setting :mq_verify_peer
+    boolean_setting :mq_api_ssl
+    boolean_setting :autoload_rails
+    boolean_setting :daemonise
+    boolean_setting :publisher_confirms
+    boolean_setting :force_publisher_confirms
+    boolean_setting :enable_http_api_use
+    boolean_setting :consumer_pool_abort_on_exception
+
+    # Set of all setting keys
+    ALL_KEYS = BOOL_KEYS + NUMBER_KEYS + STRING_KEYS
 
     def self.initialize(params = {})
       @config = default_config.merge(env_based_config).merge(params)
@@ -154,7 +169,7 @@ module Hutch
     end
 
     def self.is_bool(attr)
-      BOOL_KEYS.include?(attr.to_s)
+      BOOL_KEYS.include?(attr)
     end
 
     def self.to_bool(value)
@@ -162,7 +177,7 @@ module Hutch
     end
 
     def self.is_num(attr)
-      NUMBER_KEYS.include?(attr.to_s)
+      NUMBER_KEYS.include?(attr)
     end
 
     def self.set(attr, value)

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -20,9 +20,11 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
     hutch_config = YARD::CodeObjects::ModuleObject.new(:root, "Hutch::Config")
     collection_name = statement.first.first
     default_value = statement.parameters[1].jump(:tstring_content, :ident).source
-    (hutch_config[collection_name] ||= []) << {
+    
+    (hutch_config['setting_rows'] ||= []) << {
       name: name,
-      default_value: default_value
+      default_value: default_value,
+      type: collection_name.sub('_setting', '').capitalize
     }
   rescue => e
     $stderr.puts e.message, e.inspect

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -1,0 +1,45 @@
+# :nodoc:
+class SettingsHandlerBase < YARD::Handlers::Ruby::Base
+  handles method_call :string_setting
+  handles method_call :number_setting
+  handles method_call :boolean_setting
+
+  namespace_only
+
+  def process
+    name = statement.parameters.first.jump(:tstring_content, :ident).source
+    object = YARD::CodeObjects::MethodObject.new(namespace, name)
+    register(object)
+
+    # modify the code object for the new instance method
+    object.dynamic = true
+    # add custom metadata to the object
+    object['custom_field'] = '(Found using method_missing)'
+
+    # Module-level configuration notes
+    hutch_config = YARD::CodeObjects::ModuleObject.new(:root, "Hutch::Config")
+    collection_name = statement.first.first
+
+    (hutch_config[collection_name] ||= []) << { name: name }
+  rescue => e
+    require "pry"
+    binding.pry
+  end
+end
+
+# class RSpecItHandler < YARD::Handlers::Ruby::Base
+#   handles method_call(:it)
+
+#   def process
+#     return if owner.nil?
+#     obj = P(owner[:spec])
+#     return if obj.is_a?(Proxy)
+
+#     (obj[:specifications] ||= []) << {
+#       name: statement.parameters.first.jump(:string_content).source,
+#       file: statement.file,
+#       line: statement.line,
+#       source: statement.last.last.source.chomp
+#     }
+#   end
+# end

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -27,9 +27,5 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
       type: collection_name.sub('_setting', '').capitalize,
       description: object.docstring
     }
-  rescue => e
-    $stderr.puts e.message, e.inspect
-    #require "pry"
-    #binding.pry
   end
 end

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -19,8 +19,11 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
     # Module-level configuration notes
     hutch_config = YARD::CodeObjects::ModuleObject.new(:root, "Hutch::Config")
     collection_name = statement.first.first
-
-    (hutch_config[collection_name] ||= []) << { name: name }
+    default_value = statement.parameters[1].jump(:tstring_content, :ident).source
+    (hutch_config[collection_name] ||= []) << {
+      name: name,
+      default_value: default_value
+    }
   rescue => e
     require "pry"
     binding.pry

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -25,24 +25,8 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
       default_value: default_value
     }
   rescue => e
-    require "pry"
-    binding.pry
+    $stderr.puts e.message, e.inspect
+    #require "pry"
+    #binding.pry
   end
 end
-
-# class RSpecItHandler < YARD::Handlers::Ruby::Base
-#   handles method_call(:it)
-
-#   def process
-#     return if owner.nil?
-#     obj = P(owner[:spec])
-#     return if obj.is_a?(Proxy)
-
-#     (obj[:specifications] ||= []) << {
-#       name: statement.parameters.first.jump(:string_content).source,
-#       file: statement.file,
-#       line: statement.line,
-#       source: statement.last.last.source.chomp
-#     }
-#   end
-# end

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -11,20 +11,21 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
     object = YARD::CodeObjects::MethodObject.new(namespace, name)
     register(object)
 
-    # modify the code object for the new instance method
+    # Modify the code object for the new instance method
     object.dynamic = true
-    # add custom metadata to the object
+    # Add custom metadata to the object
     object['custom_field'] = '(Found using method_missing)'
 
     # Module-level configuration notes
     hutch_config = YARD::CodeObjects::ModuleObject.new(:root, "Hutch::Config")
     collection_name = statement.first.first
     default_value = statement.parameters[1].jump(:tstring_content, :ident).source
-    
+
     (hutch_config['setting_rows'] ||= []) << {
       name: name,
       default_value: default_value,
-      type: collection_name.sub('_setting', '').capitalize
+      type: collection_name.sub('_setting', '').capitalize,
+      description: object.docstring
     }
   rescue => e
     $stderr.puts e.message, e.inspect

--- a/lib/yard-settings/legacy.rb
+++ b/lib/yard-settings/legacy.rb
@@ -1,1 +1,0 @@
-# legacy.rb

--- a/lib/yard-settings/legacy.rb
+++ b/lib/yard-settings/legacy.rb
@@ -1,0 +1,1 @@
+# legacy.rb

--- a/lib/yard-settings/yard-settings.rb
+++ b/lib/yard-settings/yard-settings.rb
@@ -1,3 +1,2 @@
 YARD::Templates::Engine.register_template_path(File.dirname(__FILE__) + '/../../templates')
 require File.join(File.dirname(__FILE__), 'handler') if RUBY19
-require File.join(File.dirname(__FILE__), 'legacy')

--- a/lib/yard-settings/yard-settings.rb
+++ b/lib/yard-settings/yard-settings.rb
@@ -1,0 +1,3 @@
+YARD::Templates::Engine.register_template_path(File.dirname(__FILE__) + '/../../templates')
+require File.join(File.dirname(__FILE__), 'handler') if RUBY19
+require File.join(File.dirname(__FILE__), 'legacy')

--- a/templates/default/class/setup.rb
+++ b/templates/default/class/setup.rb
@@ -1,0 +1,4 @@
+def init
+  super
+  sections.push :settings
+end

--- a/templates/default/fulldoc/html/css/hutch.css
+++ b/templates/default/fulldoc/html/css/hutch.css
@@ -1,0 +1,8 @@
+.settings {
+  border-spacing: 2.5rem;
+  border-collapse: collapse;
+}
+
+.settings tbody td {
+  padding: .5em 1em;
+}

--- a/templates/default/fulldoc/html/css/hutch.css
+++ b/templates/default/fulldoc/html/css/hutch.css
@@ -3,6 +3,11 @@
   border-collapse: collapse;
 }
 
+.settings thead th {
+  text-align: left;
+}
+
+.settings thead th,
 .settings tbody td {
   padding: .5em 1em;
 }

--- a/templates/default/layout/html/settings.erb
+++ b/templates/default/layout/html/settings.erb
@@ -1,0 +1,17 @@
+<h2>Configuration settings</h2>
+<style>
+.rake_tasks { width: 800px; }
+.rake_tasks th, .take_tasks td { text-align: left; }
+</style>
+<table class="rake_tasks">
+  <% @tasks.each do |task| %>
+    <tr>
+    <th><tt><%= task.full_path %></tt></th>
+    <% if task.full_path == 'default' %>
+    <th><%= task.tag(:task_deps).text %></th>
+    <% else %>
+    <td><%= task.docstring %></td>
+    <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -5,7 +5,3 @@ end
 def stylesheets
   super + %w(css/hutch.css)
 end
-
-# def javascripts
-#   super + %w(js/hutch.js)
-# end

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -1,11 +1,11 @@
 def init
   super
-  sections.place(:settings).after_any(:alpha)
 end
 
-def settings
-  @tasks = Registry.all(:rake_task)
-  return if @tasks.empty?
-  @tasks = @tasks.sort_by {|t| t.full_path == 'default' ? '_' : t.full_path }
-  erb(:rake_tasks)
+def stylesheets
+  super + %w(css/hutch.css)
 end
+
+# def javascripts
+#   super + %w(js/hutch.js)
+# end

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -1,0 +1,11 @@
+def init
+  super
+  sections.place(:settings).after_any(:alpha)
+end
+
+def settings
+  @tasks = Registry.all(:rake_task)
+  return if @tasks.empty?
+  @tasks = @tasks.sort_by {|t| t.full_path == 'default' ? '_' : t.full_path }
+  erb(:rake_tasks)
+end

--- a/templates/default/method_details/html/settings.erb
+++ b/templates/default/method_details/html/settings.erb
@@ -1,0 +1,19 @@
+<%= object['custom_field'] %>
+<%= object['string_setting'] %>
+
+<% if object['string_setting'] || object['number_setting'] || object['boolean_setting'] %>
+<div class="tags">
+  <h3>Settings:</h3>
+  <ul class="settings">
+    <% for setting in object['string_setting'] %>
+      <li>String setting <%= setting.inspect %></li>
+    <% end %>
+    <% for setting in object['number_setting'] %>
+      <li>Number setting <%= setting.inspect %></li>
+    <% end %>
+    <% for setting in object['boolean_setting'] %>
+      <li>Boolean setting <%= setting.inspect %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>

--- a/templates/default/method_details/html/settings.erb
+++ b/templates/default/method_details/html/settings.erb
@@ -1,19 +1,5 @@
-<%= object['custom_field'] %>
-<%= object['string_setting'] %>
-
-<% if object['string_setting'] || object['number_setting'] || object['boolean_setting'] %>
-<div class="tags">
-  <h3>Settings:</h3>
-  <ul class="settings">
-    <% for setting in object['string_setting'] %>
-      <li>String setting <%= setting.inspect %></li>
-    <% end %>
-    <% for setting in object['number_setting'] %>
-      <li>Number setting <%= setting.inspect %></li>
-    <% end %>
-    <% for setting in object['boolean_setting'] %>
-      <li>Boolean setting <%= setting.inspect %></li>
-    <% end %>
-  </ul>
-</div>
+<% if object['custom_field'] %>
+<p>
+  <%= object['custom_field'] %>
+</p>
 <% end %>

--- a/templates/default/method_details/setup.rb
+++ b/templates/default/method_details/setup.rb
@@ -1,0 +1,4 @@
+def init
+  super
+  sections.last.place(:settings).after(:source)
+end

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -1,10 +1,10 @@
-<% if object['string_setting'] || object['number_setting'] || object['boolean_setting'] %>
+<% if object['setting_rows'] %>
   <h2>
     Configuration
   </h2>
 
   <div class="tags">
-    <table border="1" class="settings" style="border-spacing: 0.5rem; border-collapse: collapse;">
+    <table border="1" class="settings">
       <thead>
         <tr>
           <th>
@@ -22,33 +22,14 @@
         </tr>
       </thead>
       <tbody>
-      <% for setting in object['string_setting'] %>
+      <% for setting in object['setting_rows'] %>
         <tr>
-          <td><%= setting[:name] %></td>
+          <td><tt><%= setting[:name] %></tt></td>
           <td><%= setting[:default_value] %></td>
-          <td>String</td>
-          <td>HUTCH_<%= setting[:name].upcase %></td>
+          <td><%= setting[:type] %></td>
+          <td><tt>HUTCH_<%= setting[:name].upcase %></tt></td>
         </tr>
       <% end %>
-
-      <% for setting in object['number_setting'] %>
-        <tr>
-          <td><%= setting[:name] %></td>
-          <td><%= setting[:default_value] %></td>
-          <td>Number</td>
-          <td>HUTCH_<%= setting[:name].upcase %></td>
-        </tr>
-      <% end %>
-
-      <% for setting in object['boolean_setting'] %>
-        <tr>
-          <td><%= setting[:name] %></td>
-          <td><%= setting[:default_value] %></td>
-          <td>Boolean</td>
-          <td>HUTCH_<%= setting[:name].upcase %></td>
-        </tr>
-      <% end %>
-
       </tbody>
     </table>
   </div>

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -19,6 +19,9 @@
           <th>
             ENV variable
           </th>
+          <th>
+            Description
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -28,6 +31,7 @@
           <td><%= setting[:default_value] %></td>
           <td><%= setting[:type] %></td>
           <td><tt>HUTCH_<%= setting[:name].upcase %></tt></td>
+          <td><%= html_markup_markdown setting[:description] %></td>
         </tr>
       <% end %>
       </tbody>

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -1,0 +1,55 @@
+<% if object['string_setting'] || object['number_setting'] || object['boolean_setting'] %>
+  <h2>
+    Configuration
+  </h2>
+
+  <div class="tags">
+    <table border="1" class="settings" style="border-spacing: 0.5rem; border-collapse: collapse;">
+      <thead>
+        <tr>
+          <th>
+            Setting name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Default value
+          </th>
+          <th>
+            ENV variable
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+      <% for setting in object['string_setting'] %>
+        <tr>
+          <td><%= setting[:name] %></td>
+          <td>String</td>
+          <td>TODO</td>
+          <td>HUTCH_<%= setting[:name].upcase %></td>
+        </tr>
+      <% end %>
+
+      <% for setting in object['number_setting'] %>
+        <tr>
+          <td><%= setting[:name] %></td>
+          <td>Number</td>
+          <td>TODO</td>
+          <td>HUTCH_<%= setting[:name].upcase %></td>
+        </tr>
+      <% end %>
+
+      <% for setting in object['boolean_setting'] %>
+        <tr>
+          <td><%= setting[:name] %></td>
+          <td>Boolean</td>
+          <td>TODO</td>
+          <td>HUTCH_<%= setting[:name].upcase %></td>
+        </tr>
+      <% end %>
+
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -11,10 +11,10 @@
             Setting name
           </th>
           <th>
-            Type
+            Default value
           </th>
           <th>
-            Default value
+            Type
           </th>
           <th>
             ENV variable
@@ -25,8 +25,8 @@
       <% for setting in object['string_setting'] %>
         <tr>
           <td><%= setting[:name] %></td>
+          <td><%= setting[:default_value] %></td>
           <td>String</td>
-          <td>TODO</td>
           <td>HUTCH_<%= setting[:name].upcase %></td>
         </tr>
       <% end %>
@@ -34,8 +34,8 @@
       <% for setting in object['number_setting'] %>
         <tr>
           <td><%= setting[:name] %></td>
+          <td><%= setting[:default_value] %></td>
           <td>Number</td>
-          <td>TODO</td>
           <td>HUTCH_<%= setting[:name].upcase %></td>
         </tr>
       <% end %>
@@ -43,8 +43,8 @@
       <% for setting in object['boolean_setting'] %>
         <tr>
           <td><%= setting[:name] %></td>
+          <td><%= setting[:default_value] %></td>
           <td>Boolean</td>
-          <td>TODO</td>
           <td>HUTCH_<%= setting[:name].upcase %></td>
         </tr>
       <% end %>

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -1,0 +1,4 @@
+def init
+  super
+  sections.place(:settings).before(:children)
+end


### PR DESCRIPTION
In order to help users configure Hutch, try to tell the configuration story using YARD docs. This PR now produces docs.

![screenshot 2016-04-29 06 55 13](https://cloud.githubusercontent.com/assets/211/14908413/612ecdda-0dd7-11e6-835a-528faa11b5b1.png)

Using a YARD processor, the names, types and default values can be presented in the documentation:

![screenshot 2016-04-30 15 14 21](https://cloud.githubusercontent.com/assets/211/14935993/5aaf19b4-0ee6-11e6-9c31-803380ac37cf.png)

(Using the power of a CSS class, we could style that to be legible.)

