### PR TITLE
Docs: HTML anchor links to settings methods

### DIFF
--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -25,7 +25,14 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
       name: name,
       default_value: default_value,
       type: collection_name.sub('_setting', '').capitalize,
-      description: object.docstring
+      description: object.docstring,
+      first_line_of_description: first_line_of_description(object)
     }
+  end
+
+  def first_line_of_description(object)
+    return '' if object.docstring.blank?
+
+    p object.docstring.split("\n").first
   end
 end

--- a/lib/yard-settings/handler.rb
+++ b/lib/yard-settings/handler.rb
@@ -33,6 +33,6 @@ class SettingsHandlerBase < YARD::Handlers::Ruby::Base
   def first_line_of_description(object)
     return '' if object.docstring.blank?
 
-    p object.docstring.split("\n").first
+    object.docstring.lines.first
   end
 end

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -27,7 +27,7 @@
       <tbody>
       <% for setting in object['setting_rows'] %>
         <tr>
-          <td><tt><%= setting[:name] %></tt></td>
+          <td><tt><%= resolve_links "{Hutch::Config##{setting[:name]} #{setting[:name]}}" %></tt></td>
           <td><%= setting[:default_value] %></td>
           <td><%= setting[:type] %></td>
           <td><tt>HUTCH_<%= setting[:name].upcase %></tt></td>

--- a/templates/default/module/html/settings.erb
+++ b/templates/default/module/html/settings.erb
@@ -31,7 +31,7 @@
           <td><%= setting[:default_value] %></td>
           <td><%= setting[:type] %></td>
           <td><tt>HUTCH_<%= setting[:name].upcase %></tt></td>
-          <td><%= html_markup_markdown setting[:description] %></td>
+          <td><%= html_markup_markdown setting[:first_line_of_description] %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
[YARD can resolve internal links](http://www.rubydoc.info/gems/yard/0.8.7.2/YARD/Templates/Helpers/HtmlHelper#resolve_links-instance_method), and this brings prettier and more navigable settings documentation.

![screenshot 2016-05-09 22 20 43](https://cloud.githubusercontent.com/assets/211/15126836/4c8b5938-1634-11e6-80c3-09b01e1bb568.png)
