### PR TITLE
Message preprocessor and worker refactoring

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -12,6 +12,7 @@ require 'hutch/version'
 require 'hutch/error_handlers'
 require 'hutch/exceptions'
 require 'hutch/tracers'
+require 'hutch/main_loop'
 
 module Hutch
   def self.register_consumer(consumer)

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -198,15 +198,6 @@ module Hutch
       end
     end
 
-    # Each subscriber is run in a thread. This calls Thread#join on each of the
-    # subscriber threads.
-    def wait_on_threads(timeout)
-      # Thread#join returns nil when the timeout is hit. If any return nil,
-      # the threads didn't all join so we return false.
-      per_thread_timeout = timeout.to_f / work_pool_threads.length
-      work_pool_threads.none? { |thread| thread.join(per_thread_timeout).nil? }
-    end
-
     def stop
       if defined?(JRUBY_VERSION)
         channel.close
@@ -346,10 +337,6 @@ module Hutch
     rescue Hutch::Adapter::ConnectionRefused => ex
       logger.error "amqp connection error: #{ex.message.downcase}"
       raise ConnectionError.new("couldn't connect to rabbitmq at #{uri}. Check your configuration, network connectivity and RabbitMQ logs.")
-    end
-
-    def work_pool_threads
-      channel_work_pool.threads || []
     end
 
     def channel_work_pool

--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -16,6 +16,7 @@ module Hutch
 
     # Run a Hutch worker with the command line interface.
     def run(argv = ARGV)
+      Hutch::Config.initialize
       parse_options(argv)
 
       daemonise_process

--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -5,6 +5,11 @@ require 'hutch/logging'
 require 'hutch/exceptions'
 require 'hutch/config'
 
+=begin
+Hutch::CLI handles turning CLI commands and options into method calls on Hutch
+classes.
+=end
+
 module Hutch
   class CLI
     include Logging
@@ -84,9 +89,7 @@ module Hutch
     # Kick off the work loop. This method returns when the worker is shut down
     # gracefully (with a SIGQUIT, SIGTERM or SIGINT).
     def start_work_loop
-      Hutch.connect
-      @worker = Hutch::Worker.new(Hutch.broker, Hutch.consumers, Hutch::Config.setup_procs)
-      @worker.run
+      Hutch::Worker.new.run
       :success
     rescue ConnectionError, AuthenticationError, WorkerSetupError => ex
       logger.fatal ex.message

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -1,4 +1,5 @@
 require 'hutch/error_handlers/logger'
+require 'hutch/setup/queues'
 require 'hutch/tracers'
 require 'hutch/serializers/json'
 require 'erb'
@@ -156,7 +157,8 @@ module Hutch
         # note that this is not a list, it is a chain of responsibility
         # that will fall back to "nack unconditionally"
         error_acknowledgements: [],
-        setup_procs: [],
+        setup_procs: [ Hutch::Setup::Queues ],
+        message_preprocessing_proc: Hutch::MessagePreprocessor,
         tracer: Hutch::Tracers::NullTracer,
         namespace: nil,
         pidfile: nil,

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -162,6 +162,7 @@ module Hutch
         tracer: Hutch::Tracers::NullTracer,
         namespace: nil,
         pidfile: nil,
+        client_logger: nil,
         serializer: Hutch::Serializers::JSON
       })
     end

--- a/lib/hutch/main_loop.rb
+++ b/lib/hutch/main_loop.rb
@@ -1,0 +1,41 @@
+require 'hutch/logging'
+
+module Hutch
+  class MainLoop
+    include Logging
+
+    SHUTDOWN_SIGNALS = %w(QUIT TERM INT)
+
+    def self.loop_until_signaled
+      new.loop_until_signaled
+    end
+
+    def loop_until_signaled
+      self.sig_read, self.sig_write = IO.pipe
+
+      register_signal_handlers
+      wait_for_signal
+
+      sig = sig_read.gets.strip.downcase
+      logger.info "caught sig#{sig}, stopping hutch..."
+    end
+
+    private
+
+    attr_accessor :sig_read, :sig_write
+
+    def wait_for_signal
+      IO.select([sig_read])
+    end
+
+    def register_signal_handlers
+      SHUTDOWN_SIGNALS.each do |sig|
+        # This needs to be reentrant, so we queue up signals to be handled
+        # in the run loop, rather than acting on signals here
+        trap(sig) do
+          sig_write.puts(sig)
+        end
+      end
+    end
+  end
+end

--- a/lib/hutch/message_preprocessor.rb
+++ b/lib/hutch/message_preprocessor.rb
@@ -1,0 +1,64 @@
+require 'hutch/message'
+require 'hutch/adapter'
+
+module Hutch
+  class MessagePreprocessor
+    include Logging
+
+    def self.to_proc
+      Proc.new do |*args|
+        delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
+        new(Hutch.broker).call(consumer, delivery_info, properties, payload)
+      end
+    end
+
+    def initialize(broker)
+      self.broker = broker
+    end
+
+    # Called internally when a new messages comes in from RabbitMQ. Responsible
+    # for wrapping up the message and passing it to the consumer.
+    def call(consumer, delivery_info, properties, payload)
+      serializer = consumer.get_serializer || Hutch::Config[:serializer]
+      logger.debug {
+        spec   = serializer.binary? ? "#{payload.bytesize} bytes" : "#{payload}"
+        "message(#{properties.message_id || '-'}): " +
+          "routing key: #{delivery_info.routing_key}, " +
+          "consumer: #{consumer}, " +
+          "payload: #{spec}"
+      }
+
+      message = Message.new(delivery_info, properties, payload, serializer)
+      consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = broker, delivery_info }
+      with_tracing(consumer_instance).handle(message)
+      broker.ack(delivery_info.delivery_tag)
+    rescue => ex
+      acknowledge_error(delivery_info, properties, broker, ex)
+      handle_error(properties.message_id, payload, consumer, ex)
+    end
+
+    attr_accessor :broker
+
+    def with_tracing(klass)
+      Hutch::Config[:tracer].new(klass)
+    end
+
+    def handle_error(message_id, payload, consumer, ex)
+      Hutch::Config[:error_handlers].each do |backend|
+        backend.handle(message_id, payload, consumer, ex)
+      end
+    end
+
+    def acknowledge_error(delivery_info, properties, broker, ex)
+      acks = error_acknowledgements +
+        [Hutch::Acknowledgements::NackOnAllFailures.new]
+      acks.find do |backend|
+        backend.handle(delivery_info, properties, broker, ex)
+      end
+    end
+
+    def error_acknowledgements
+      Hutch::Config[:error_acknowledgements]
+    end
+  end
+end

--- a/lib/hutch/setup/queues.rb
+++ b/lib/hutch/setup/queues.rb
@@ -32,7 +32,7 @@ module Hutch
         queue = broker.queue(consumer.get_queue_name, consumer.get_arguments)
         broker.bind_queue(queue, consumer.routing_keys)
 
-        queue.subscribe(manual_ack: true, &Config[:message_preprocessing_proc])
+        queue.subscribe(manual_ack: true, &Config[:message_preprocessing_proc].to_proc(consumer))
       end
     end
   end

--- a/lib/hutch/setup/queues.rb
+++ b/lib/hutch/setup/queues.rb
@@ -1,0 +1,39 @@
+require 'hutch/logging'
+require 'hutch/config'
+require 'hutch/message_preprocessor'
+require 'hutch/acknowledgements/nack_on_all_failures'
+
+module Hutch
+  module Setup
+    class Queues
+      include Logging
+
+      def self.call
+        new(Hutch.broker, Hutch.consumers).call
+      end
+
+      def initialize(broker, consumers)
+        self.broker = broker
+        self.consumers = consumers
+      end
+
+      def call
+        logger.info 'setting up queues'
+        consumers.each { |consumer| setup_queue(consumer) }
+      end
+
+      private
+
+      attr_accessor :broker, :consumers
+
+      # Bind a consumer's routing keys to its queue, and set up a subscription to
+      # receive messages sent to the queue.
+      def setup_queue(consumer)
+        queue = broker.queue(consumer.get_queue_name, consumer.get_arguments)
+        broker.bind_queue(queue, consumer.routing_keys)
+
+        queue.subscribe(manual_ack: true, &Config[:message_preprocessing_proc])
+      end
+    end
+  end
+end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -1,165 +1,29 @@
-require 'hutch/message'
-require 'hutch/logging'
-require 'hutch/broker'
-require 'hutch/acknowledgements/nack_on_all_failures'
-require 'carrot-top'
+require 'hutch'
+
+=begin
+Hutch::Worker is the minimum needed to run a Hutch process.
+
+Usage:
+Hutch::Worker.new.run
+=end
 
 module Hutch
   class Worker
-    include Logging
-
-    SHUTDOWN_SIGNALS = %w(QUIT TERM INT)
-
-    def initialize(broker, consumers, setup_procs)
-      @broker        = broker
-      self.consumers = consumers
-      self.setup_procs = setup_procs
-    end
-
-    # Run the main event loop. The consumers will be set up with queues, and
-    # process the messages in their respective queues indefinitely. This method
-    # never returns.
     def run
-      setup_queues
-      setup_procs.each(&:call)
-
-      # Set up signal handlers for graceful shutdown
-      register_signal_handlers
-
-      main_loop
-    end
-
-    def main_loop
-      if defined?(JRUBY_VERSION)
-        # Binds shutdown listener to notify main thread if channel was closed
-        bind_shutdown_handler
-
-        handle_signals until shutdown_not_called?(0.1)
-      else
-        # Take a break from Thread#join every 0.1 seconds to check if we've
-        # been sent any signals
-        handle_signals until @broker.wait_on_threads(0.1)
-      end
-    end
-
-    # Register handlers for SIGQUIT, SIGTERM, SIGINT to shut down the worker
-    # gracefully. Forceful shutdowns are very bad!
-    def register_signal_handlers
-      Thread.main[:signal_queue] = []
-      supported_shutdown_signals.each do |sig|
-        # This needs to be reentrant, so we queue up signals to be handled
-        # in the run loop, rather than acting on signals here
-        trap(sig) do
-          Thread.main[:signal_queue] << sig
-        end
-      end
-    end
-
-    # Handle any pending signals
-    def handle_signals
-      signal = Thread.main[:signal_queue].shift
-      if signal
-        logger.info "caught sig#{signal.downcase}, stopping hutch..."
-        stop
-      end
-    end
-
-    # Stop a running worker by killing all subscriber threads.
-    def stop
-      @broker.stop
-    end
-
-    # Binds shutdown handler, called if channel is closed or network Failed
-    def bind_shutdown_handler
-      @broker.channel.on_shutdown do
-        Thread.main[:shutdown_received] = true
-      end
-    end
-
-    # Checks if shutdown handler was called, then sleeps for interval
-    def shutdown_not_called?(interval)
-      if Thread.main[:shutdown_received]
-        true
-      else
-        sleep(interval)
-        false
-      end
-    end
-
-    # Set up the queues for each of the worker's consumers.
-    def setup_queues
-      logger.info 'setting up queues'
-      @consumers.each { |consumer| setup_queue(consumer) }
-    end
-
-    # Bind a consumer's routing keys to its queue, and set up a subscription to
-    # receive messages sent to the queue.
-    def setup_queue(consumer)
-      queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
-      @broker.bind_queue(queue, consumer.routing_keys)
-
-      queue.subscribe(manual_ack: true) do |*args|
-        delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
-        handle_message(consumer, delivery_info, properties, payload)
-      end
-    end
-
-    # Called internally when a new messages comes in from RabbitMQ. Responsible
-    # for wrapping up the message and passing it to the consumer.
-    def handle_message(consumer, delivery_info, properties, payload)
-      serializer = consumer.get_serializer || Hutch::Config[:serializer]
-      logger.debug {
-        spec   = serializer.binary? ? "#{payload.bytesize} bytes" : "#{payload}"
-        "message(#{properties.message_id || '-'}): " +
-        "routing key: #{delivery_info.routing_key}, " +
-        "consumer: #{consumer}, " +
-        "payload: #{spec}"
-      }
-
-      message = Message.new(delivery_info, properties, payload, serializer)
-      consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = @broker, delivery_info }
-      with_tracing(consumer_instance).handle(message)
-      @broker.ack(delivery_info.delivery_tag)
-    rescue => ex
-      acknowledge_error(delivery_info, properties, @broker, ex)
-      handle_error(properties.message_id, payload, consumer, ex)
-    end
-
-    def with_tracing(klass)
-      Hutch::Config[:tracer].new(klass)
-    end
-
-    def handle_error(message_id, payload, consumer, ex)
-      Hutch::Config[:error_handlers].each do |backend|
-        backend.handle(message_id, payload, consumer, ex)
-      end
-    end
-
-    def acknowledge_error(delivery_info, properties, broker, ex)
-      acks = error_acknowledgements +
-        [Hutch::Acknowledgements::NackOnAllFailures.new]
-      acks.find do |backend|
-        backend.handle(delivery_info, properties, broker, ex)
-      end
-    end
-
-    def consumers=(val)
-      if val.empty?
-        logger.warn "no consumer loaded, ensure there's no configuration issue"
-      end
-      @consumers = val
-    end
-
-    def error_acknowledgements
-      Hutch::Config[:error_acknowledgements]
+      start
+      MainLoop.loop_until_signaled
+      stop
     end
 
     private
 
-    attr_accessor :setup_procs
+    def start
+      Hutch.connect
+      Config[:setup_procs].each(&:call)
+    end
 
-    def supported_shutdown_signals
-      SHUTDOWN_SIGNALS.keep_if { |s| Signal.list.keys.include? s }.map(&:to_sym)
+    def stop
+      Hutch.broker.stop
     end
   end
 end

--- a/spec/consumer_helper.rb
+++ b/spec/consumer_helper.rb
@@ -1,0 +1,16 @@
+module ConsumerFactory
+  @@consumer_inc ||= "0"
+
+  def build_consumer
+    @@consumer_inc = @@consumer_inc.next
+
+    Class.new {
+      include Hutch::Consumer
+
+      consume %w( a b c )
+      queue_name 'consumer' + @@consumer_inc
+    }
+  end
+end
+
+RSpec.configuration.after { Hutch.consumers.clear }

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -281,21 +281,6 @@ describe Hutch::Broker do
     end
   end
 
-  describe '#wait_on_threads' do
-    let(:thread) { double('Thread') }
-    before { allow(broker).to receive(:work_pool_threads).and_return(threads) }
-
-    context 'when all threads finish within the timeout' do
-      let(:threads) { [double(join: thread), double(join: thread)] }
-      specify { expect(broker.wait_on_threads(1)).to be_truthy }
-    end
-
-    context 'when timeout expires for one thread' do
-      let(:threads) { [double(join: thread), double(join: nil)] }
-      specify { expect(broker.wait_on_threads(1)).to be_falsey }
-    end
-  end
-
   describe '#stop', adapter: :bunny do
     let(:thread_1) { double('Thread') }
     let(:thread_2) { double('Thread') }

--- a/spec/hutch/main_loop_spec.rb
+++ b/spec/hutch/main_loop_spec.rb
@@ -1,0 +1,32 @@
+require 'hutch/main_loop'
+
+RSpec.describe Hutch::MainLoop do
+  describe '.loop_until_signaled' do
+    def start_kill_thread(signal)
+      Thread.new do
+        # sleep allows the worker time to set up the signal handling
+        # before the kill signal is sent.
+        sleep 0.001
+        Process.kill signal, 0
+      end
+    end
+
+    %w(QUIT TERM INT).each do |signal|
+      context "a #{signal} signal is received" do
+        it "logs that hutch is stopping" do
+          expect(Hutch::Logging.logger).to receive(:info)
+            .with("caught sig#{signal.downcase}, stopping hutch...")
+
+          start_kill_thread(signal)
+          described_class.loop_until_signaled
+        end
+      end
+    end
+  end
+
+  describe Hutch::MainLoop::SHUTDOWN_SIGNALS do
+    it "includes only things in Signal.list.keys" do
+      expect(described_class).to eq(described_class & Signal.list.keys)
+    end
+  end
+end

--- a/spec/hutch/message_preprocessor_spec.rb
+++ b/spec/hutch/message_preprocessor_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+require 'consumer_helper'
+
+describe Hutch::MessagePreprocessor do
+  include ConsumerFactory
+
+  let(:broker) { instance_double("Hutch::Broker") }
+  subject(:handler) { described_class.new(broker) }
+
+  describe '#call' do
+    let(:payload) { '{}' }
+    let(:consumer_instance) { double('Consumer instance') }
+    let(:delivery_info) { double('Delivery Info', routing_key: '',
+                                 delivery_tag: 'dt') }
+    let(:properties) { double('Properties', message_id: nil, content_type: "application/json") }
+    let(:consumer) { build_consumer }
+
+    before { allow(consumer).to receive(:new).and_return(consumer_instance) }
+    before { allow(broker).to receive(:ack) }
+    before { allow(broker).to receive(:nack) }
+    before { allow(consumer_instance).to receive(:broker=) }
+    before { allow(consumer_instance).to receive(:delivery_info=) }
+
+    it 'passes the message to the consumer' do
+      expect(consumer_instance).to receive(:process).
+        with(an_instance_of(Hutch::Message))
+      handler.call(consumer, delivery_info, properties, payload)
+    end
+
+    it 'acknowledges the message' do
+      allow(consumer_instance).to receive(:process)
+      expect(broker).to receive(:ack).with(delivery_info.delivery_tag)
+      handler.call(consumer, delivery_info, properties, payload)
+    end
+
+    context 'when the consumer fails and a requeue is configured' do
+
+      it 'requeues the message' do
+        allow(consumer_instance).to receive(:process).and_raise('failed')
+        requeuer = double
+        allow(requeuer).to receive(:handle).ordered { |delivery_info, properties, broker, e|
+          broker.requeue delivery_info.delivery_tag
+          true
+        }
+        allow(handler).to receive(:error_acknowledgements).and_return([requeuer])
+        expect(broker).to_not receive(:ack)
+        expect(broker).to_not receive(:nack)
+        expect(broker).to receive(:requeue)
+
+        handler.call(consumer, delivery_info, properties, payload)
+      end
+    end
+
+
+    context 'when the consumer raises an exception' do
+      before { allow(consumer_instance).to receive(:process).and_raise('a consumer error') }
+
+      it 'logs the error' do
+        Hutch::Config[:error_handlers].each do |backend|
+          expect(backend).to receive(:handle)
+        end
+        handler.call(consumer, delivery_info, properties, payload)
+      end
+
+      it 'rejects the message' do
+        expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
+        handler.call(consumer, delivery_info, properties, payload)
+      end
+    end
+
+    context "when the payload is not valid json" do
+      let(:payload) { "Not Valid JSON" }
+
+      it 'logs the error' do
+        Hutch::Config[:error_handlers].each do |backend|
+          expect(backend).to receive(:handle)
+        end
+        handler.call(consumer, delivery_info, properties, payload)
+      end
+
+      it 'rejects the message' do
+        expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
+        handler.call(consumer, delivery_info, properties, payload)
+      end
+    end
+  end
+
+
+  describe '#acknowledge_error' do
+    let(:delivery_info) { double('Delivery Info', routing_key: '',
+                                 delivery_tag: 'dt') }
+    let(:properties) { double('Properties', message_id: 'abc123') }
+
+    subject { handler.acknowledge_error delivery_info, properties, broker, StandardError.new }
+
+    it 'stops when it runs a successful acknowledgement' do
+      skip_ack = double handle: false
+      always_ack = double handle: true
+      never_used = double handle: true
+
+      allow(handler).
+        to receive(:error_acknowledgements).
+        and_return([skip_ack, always_ack, never_used])
+
+      expect(never_used).to_not receive(:handle)
+
+      subject
+    end
+
+    it 'defaults to nacking' do
+      skip_ack = double handle: false
+
+      allow(handler).
+        to receive(:error_acknowledgements).
+        and_return([skip_ack, skip_ack])
+
+      expect(broker).to receive(:nack)
+
+      subject
+    end
+  end
+end

--- a/spec/hutch/message_preprocessor_spec.rb
+++ b/spec/hutch/message_preprocessor_spec.rb
@@ -1,19 +1,28 @@
 require 'spec_helper'
 require 'consumer_helper'
+require 'hutch/message_preprocessor'
 
 describe Hutch::MessagePreprocessor do
   include ConsumerFactory
 
+  subject(:handler) { described_class.new(broker, consumer, args) }
   let(:broker) { instance_double("Hutch::Broker") }
-  subject(:handler) { described_class.new(broker) }
+  let(:consumer) { build_consumer }
+  let(:args) { [double.as_null_object, double.as_null_object, double.as_null_object] }
+  let(:payload) { '{}' }
+  let(:delivery_info) { double('Delivery Info', routing_key: '',
+                               delivery_tag: 'dt') }
+  let(:properties) { double('Properties', message_id: nil, content_type: "application/json") }
+
+  before do
+    allow(Hutch::Adapter)
+      .to receive(:decode_message)
+      .with(*args)
+      .and_return([delivery_info, properties, payload])
+  end
 
   describe '#call' do
-    let(:payload) { '{}' }
     let(:consumer_instance) { double('Consumer instance') }
-    let(:delivery_info) { double('Delivery Info', routing_key: '',
-                                 delivery_tag: 'dt') }
-    let(:properties) { double('Properties', message_id: nil, content_type: "application/json") }
-    let(:consumer) { build_consumer }
 
     before { allow(consumer).to receive(:new).and_return(consumer_instance) }
     before { allow(broker).to receive(:ack) }
@@ -24,13 +33,13 @@ describe Hutch::MessagePreprocessor do
     it 'passes the message to the consumer' do
       expect(consumer_instance).to receive(:process).
         with(an_instance_of(Hutch::Message))
-      handler.call(consumer, delivery_info, properties, payload)
+      handler.call
     end
 
     it 'acknowledges the message' do
       allow(consumer_instance).to receive(:process)
       expect(broker).to receive(:ack).with(delivery_info.delivery_tag)
-      handler.call(consumer, delivery_info, properties, payload)
+      handler.call
     end
 
     context 'when the consumer fails and a requeue is configured' do
@@ -47,7 +56,7 @@ describe Hutch::MessagePreprocessor do
         expect(broker).to_not receive(:nack)
         expect(broker).to receive(:requeue)
 
-        handler.call(consumer, delivery_info, properties, payload)
+        handler.call
       end
     end
 
@@ -59,12 +68,31 @@ describe Hutch::MessagePreprocessor do
         Hutch::Config[:error_handlers].each do |backend|
           expect(backend).to receive(:handle)
         end
-        handler.call(consumer, delivery_info, properties, payload)
+        handler.call
       end
 
       it 'rejects the message' do
         expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
-        handler.call(consumer, delivery_info, properties, payload)
+        handler.call
+      end
+
+      it 'stops when it runs a successful acknowledgement' do
+        skip_ack = double handle: false
+        always_ack = double handle: true
+        never_used = double handle: true
+
+        allow(handler).
+          to receive(:error_acknowledgements).
+          and_return([skip_ack, always_ack, never_used])
+
+        expect(never_used).to_not receive(:handle)
+        handler.call
+      end
+
+      it 'defaults to nacking' do
+        expect(broker).to receive(:nack)
+
+        handler.call
       end
     end
 
@@ -75,48 +103,26 @@ describe Hutch::MessagePreprocessor do
         Hutch::Config[:error_handlers].each do |backend|
           expect(backend).to receive(:handle)
         end
-        handler.call(consumer, delivery_info, properties, payload)
+        handler.call
       end
 
       it 'rejects the message' do
         expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
-        handler.call(consumer, delivery_info, properties, payload)
+        handler.call
       end
     end
   end
 
+  describe ".to_proc" do
+    it "returns a proc that initializes and calls a consumer" do
+      expect(Hutch).to receive(:broker).and_return(broker)
+      expect(described_class)
+        .to receive(:new)
+        .with(broker, consumer, args)
+        .and_return(handler)
+      expect(handler).to receive(:call)
 
-  describe '#acknowledge_error' do
-    let(:delivery_info) { double('Delivery Info', routing_key: '',
-                                 delivery_tag: 'dt') }
-    let(:properties) { double('Properties', message_id: 'abc123') }
-
-    subject { handler.acknowledge_error delivery_info, properties, broker, StandardError.new }
-
-    it 'stops when it runs a successful acknowledgement' do
-      skip_ack = double handle: false
-      always_ack = double handle: true
-      never_used = double handle: true
-
-      allow(handler).
-        to receive(:error_acknowledgements).
-        and_return([skip_ack, always_ack, never_used])
-
-      expect(never_used).to_not receive(:handle)
-
-      subject
-    end
-
-    it 'defaults to nacking' do
-      skip_ack = double handle: false
-
-      allow(handler).
-        to receive(:error_acknowledgements).
-        and_return([skip_ack, skip_ack])
-
-      expect(broker).to receive(:nack)
-
-      subject
+      described_class.to_proc(consumer).call(*args)
     end
   end
 end

--- a/spec/hutch/message_preprocessor_spec.rb
+++ b/spec/hutch/message_preprocessor_spec.rb
@@ -6,7 +6,7 @@ describe Hutch::MessagePreprocessor do
   include ConsumerFactory
 
   subject(:handler) { described_class.new(broker, consumer, args) }
-  let(:broker) { instance_double("Hutch::Broker") }
+  let(:broker) { Hutch::Broker.new }
   let(:consumer) { build_consumer }
   let(:args) { [double.as_null_object, double.as_null_object, double.as_null_object] }
   let(:payload) { '{}' }

--- a/spec/hutch/setup/queues_spec.rb
+++ b/spec/hutch/setup/queues_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'consumer_helper'
+require 'hutch/setup/queues'
+
+describe Hutch::Setup::Queues do
+  include ConsumerFactory
+
+  let(:broker) { instance_double("Hutch::Broker") }
+  let(:consumers) { Array.new(2) { build_consumer } }
+  subject(:setup_performer) { described_class.new(broker, consumers) }
+
+  describe '#call' do
+    it 'sets up queues for each of the consumers' do
+      consumers.each do |consumer|
+        queue = instance_double('Bunny::Queue')
+        expect(broker).to receive(:queue)
+          .with(consumer.get_queue_name, consumer.get_arguments)
+          .and_return(queue)
+        expect(broker).to receive(:bind_queue)
+          .with(queue, consumer.routing_keys)
+
+        prc = Proc.new {}
+        expect(Hutch::Config[:message_preprocessing_proc])
+          .to receive(:to_proc).and_return(prc)
+        expect(queue).to receive(:subscribe).with(manual_ack: true) do |&blk|
+          expect(blk).to eq(prc)
+        end
+      end
+
+      setup_performer.call
+    end
+  end
+
+  describe ".call" do
+    it "delegates to #call with default arguments" do
+      expect(described_class)
+        .to receive(:new)
+        .with(Hutch.broker, Hutch.consumers)
+        .and_return(setup_performer)
+      expect(setup_performer)
+        .to receive(:call)
+
+      described_class.call
+    end
+  end
+end

--- a/spec/hutch/setup/queues_spec.rb
+++ b/spec/hutch/setup/queues_spec.rb
@@ -5,7 +5,7 @@ require 'hutch/setup/queues'
 describe Hutch::Setup::Queues do
   include ConsumerFactory
 
-  let(:broker) { instance_double("Hutch::Broker") }
+  let(:broker) { Hutch::Broker.new }
   let(:consumers) { Array.new(2) { build_consumer } }
   subject(:setup_performer) { described_class.new(broker, consumers) }
 

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -3,7 +3,7 @@ require 'hutch/worker'
 
 describe Hutch::Worker do
   let(:setup_procs) { Array.new(2) { Proc.new {} } }
-  let(:broker) { instance_double("Hutch::Broker") }
+  let(:broker) { Hutch::Broker.new }
   let(:worker) { subject }
 
   describe "#run" do

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -2,163 +2,28 @@ require 'spec_helper'
 require 'hutch/worker'
 
 describe Hutch::Worker do
-  let(:consumer) { double('Consumer', routing_keys: %w( a b c ),
-                          get_queue_name: 'consumer', get_arguments: {},
-                          get_serializer: nil) }
-  let(:consumers) { [consumer, double('Consumer')] }
-  let(:broker) { Hutch::Broker.new }
   let(:setup_procs) { Array.new(2) { Proc.new {} } }
-  subject(:worker) { Hutch::Worker.new(broker, consumers, setup_procs) }
+  let(:broker) { instance_double("Hutch::Broker") }
+  let(:worker) { subject }
 
-  describe ".#run" do
-    it "calls each setup proc" do
-      setup_procs.each { |prc| expect(prc).to receive(:call) }
-      allow(worker).to receive(:setup_queues)
-      allow(worker).to receive(:register_signal_handlers)
-      allow(worker).to receive(:main_loop)
+  describe "#run" do
+    around do |ex|
+      old_procs = Hutch::Config[:setup_procs]
+      Hutch::Config[:setup_procs] = setup_procs
+      ex.run
+      Hutch::Config[:setup_procs] = old_procs
+    end
+
+    it "starts a worker by calling things in the proper order" do
+      expect(Hutch).to receive(:connect).ordered
+      setup_procs.each do |prc|
+        expect(prc).to receive(:call).ordered
+      end
+      expect(Hutch::MainLoop).to receive(:loop_until_signaled).ordered
+      allow(Hutch).to receive(:broker).and_return(broker)
+      expect(broker).to receive(:stop).ordered
 
       worker.run
     end
   end
-
-  describe '#setup_queues' do
-    it 'sets up queues for each of the consumers' do
-      consumers.each do |consumer|
-        expect(worker).to receive(:setup_queue).with(consumer)
-      end
-      worker.setup_queues
-    end
-  end
-
-  describe '#setup_queue' do
-    let(:queue) { double('Queue', bind: nil, subscribe: nil) }
-    before { allow(broker).to receive_messages(queue: queue, bind_queue: nil) }
-
-    it 'creates a queue' do
-      expect(broker).to receive(:queue).with(consumer.get_queue_name, consumer.get_arguments).and_return(queue)
-      worker.setup_queue(consumer)
-    end
-
-    it 'binds the queue to each of the routing keys' do
-      expect(broker).to receive(:bind_queue).with(queue, %w( a b c ))
-      worker.setup_queue(consumer)
-    end
-
-    it 'sets up a subscription' do
-      expect(queue).to receive(:subscribe).with(manual_ack: true)
-      worker.setup_queue(consumer)
-    end
-  end
-
-  describe '#handle_message' do
-    let(:payload) { '{}' }
-    let(:consumer_instance) { double('Consumer instance') }
-    let(:delivery_info) { double('Delivery Info', routing_key: '',
-                                 delivery_tag: 'dt') }
-    let(:properties) { double('Properties', message_id: nil, content_type: "application/json") }
-    before { allow(consumer).to receive_messages(new: consumer_instance) }
-    before { allow(broker).to receive(:ack) }
-    before { allow(broker).to receive(:nack) }
-    before { allow(consumer_instance).to receive(:broker=) }
-    before { allow(consumer_instance).to receive(:delivery_info=) }
-
-    it 'passes the message to the consumer' do
-      expect(consumer_instance).to receive(:process).
-                        with(an_instance_of(Hutch::Message))
-      worker.handle_message(consumer, delivery_info, properties, payload)
-    end
-
-    it 'acknowledges the message' do
-      allow(consumer_instance).to receive(:process)
-      expect(broker).to receive(:ack).with(delivery_info.delivery_tag)
-      worker.handle_message(consumer, delivery_info, properties, payload)
-    end
-
-    context 'when the consumer fails and a requeue is configured' do
-
-      it 'requeues the message' do
-        allow(consumer_instance).to receive(:process).and_raise('failed')
-        requeuer = double
-        allow(requeuer).to receive(:handle).ordered { |delivery_info, properties, broker, e|
-          broker.requeue delivery_info.delivery_tag
-          true
-        }
-        allow(worker).to receive(:error_acknowledgements).and_return([requeuer])
-        expect(broker).to_not receive(:ack)
-        expect(broker).to_not receive(:nack)
-        expect(broker).to receive(:requeue)
-
-        worker.handle_message(consumer, delivery_info, properties, payload)
-      end
-    end
-
-
-    context 'when the consumer raises an exception' do
-      before { allow(consumer_instance).to receive(:process).and_raise('a consumer error') }
-
-      it 'logs the error' do
-        Hutch::Config[:error_handlers].each do |backend|
-          expect(backend).to receive(:handle)
-        end
-        worker.handle_message(consumer, delivery_info, properties, payload)
-      end
-
-      it 'rejects the message' do
-        expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
-        worker.handle_message(consumer, delivery_info, properties, payload)
-      end
-    end
-
-    context "when the payload is not valid json" do
-      let(:payload) { "Not Valid JSON" }
-
-      it 'logs the error' do
-        Hutch::Config[:error_handlers].each do |backend|
-          expect(backend).to receive(:handle)
-        end
-        worker.handle_message(consumer, delivery_info, properties, payload)
-      end
-
-      it 'rejects the message' do
-        expect(broker).to receive(:nack).with(delivery_info.delivery_tag)
-        worker.handle_message(consumer, delivery_info, properties, payload)
-      end
-    end
-  end
-
-
-  describe '#acknowledge_error' do
-    let(:delivery_info) { double('Delivery Info', routing_key: '',
-                                 delivery_tag: 'dt') }
-    let(:properties) { double('Properties', message_id: 'abc123') }
-
-    subject { worker.acknowledge_error delivery_info, properties, broker, StandardError.new }
-
-    it 'stops when it runs a successful acknowledgement' do
-      skip_ack = double handle: false
-      always_ack = double handle: true
-      never_used = double handle: true
-
-      allow(worker).
-        to receive(:error_acknowledgements).
-        and_return([skip_ack, always_ack, never_used])
-
-      expect(never_used).to_not receive(:handle)
-
-      subject
-    end
-
-    it 'defaults to nacking' do
-      skip_ack = double handle: false
-
-      allow(worker).
-        to receive(:error_acknowledgements).
-        and_return([skip_ack, skip_ack])
-
-      expect(broker).to receive(:nack)
-
-      subject
-    end
-  end
 end
-


### PR DESCRIPTION
Thought I would finish this refactoring up because it is an interesting problem space and I liked the direction it was taking. You mentioned having a changeable preprocessor before, so I added in a config var that you can set to change the pre-processing.

The main thrust of refactoring is that the worker class is one of the central parts of Hutch, and as such it was made as simple as possible. Loop logic, queue setup logic, and message pre-processing logic was moved out and tested.

One concern is that some public functions in worker were moved to other classes and some of those were further made private. My thought was that they looked like they were only public for testing purposes, but you would know better than me. If this is merged you might want to make the next release a major version change just in case.