### PR TITLE
Send payload in Sentry error handler

### DIFF
--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -16,7 +16,7 @@ module Hutch
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Sentry"
         logger.error prefix + "#{ex.class} - #{ex.message}"
-        Raven.capture_exception(ex)
+        Raven.capture_exception(ex, extra: { payload: payload })
       end
     end
   end

--- a/spec/hutch/error_handlers/sentry_spec.rb
+++ b/spec/hutch/error_handlers/sentry_spec.rb
@@ -13,7 +13,7 @@ describe Hutch::ErrorHandlers::Sentry do
     end
 
     it "logs the error to Sentry" do
-      expect(Raven).to receive(:capture_exception).with(error)
+      expect(Raven).to receive(:capture_exception).with(error, extra: { payload: "{}" })
       error_handler.handle("1", "{}", double, error)
     end
   end


### PR DESCRIPTION
When debugging errors in Hutch consumers, it's useful to be able to see the problematic message payload.  The error handlers for Airbrake and Honeybadger both send the payload as part of the notification, but the Sentry error handler does not.

This PR adds the payload in the `extra` information for Sentry, meaning that it'll show up alongside the error.