### PR TITLE
Config: .set and .get work with Strings, Symbols

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -191,8 +191,8 @@ module Hutch
     end
 
     def self.get(attr)
-      check_attr(attr)
-      user_config[attr]
+      check_attr(attr.to_sym)
+      user_config[attr.to_sym]
     end
 
     def self.key_for(attr)
@@ -213,8 +213,8 @@ module Hutch
     end
 
     def self.set(attr, value)
-      check_attr(attr)
-      user_config[attr] = value
+      check_attr(attr.to_sym)
+      user_config[attr.to_sym] = value
     end
 
     class << self

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -161,4 +161,11 @@ YAML
       end
     end
   end
+
+  context 'developer ergonomics' do
+    it 'will accept strings and symbols as config keys' do
+      expect(Hutch::Config.get(:mq_host)).to eq '127.0.0.1'
+      expect(Hutch::Config.get('mq_host')).to eq '127.0.0.1'
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces a change which avoids throwing errors like "No config setting 'mq_host' exists" when the user gave a String instead of a Symbol.