### PR TITLE
Config: Defaults and ENV-loaded values stay

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -245,6 +245,7 @@ module Hutch
     end
 
     private
+
     def api_config
       @api_config ||= OpenStruct.new.tap do |config|
         config.host = @config[:mq_api_host]

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -134,9 +134,12 @@ module Hutch
     ALL_KEYS = @boolean_keys + @number_keys + @string_keys
 
     def self.initialize(params = {})
-      @config = default_config
-      @config.merge!(env_based_config).merge!(params)
-      define_methods
+      unless @config
+        @config = default_config
+        define_methods
+        @config.merge!(env_based_config)
+      end
+      @config.merge!(params)
       @config
     end
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -267,3 +267,4 @@ module Hutch
     end
   end
 end
+Hutch::Config.initialize

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -2,8 +2,16 @@ require 'spec_helper'
 require 'hutch/broker'
 
 describe Hutch::Broker do
-  let(:config) { Hutch::Config.initialize(client_logger: Hutch::Logging.logger) }
-  subject(:broker) { Hutch::Broker.new(config) }
+  before do
+    Hutch::Config.initialize(client_logger: Hutch::Logging.logger)
+    @config = Hutch::Config.to_hash
+  end
+  let!(:config) { @config }
+  after do
+    Hutch::Config.instance_variable_set(:@config, nil)
+    Hutch::Config.initialize
+  end
+  let(:broker) { Hutch::Broker.new(config) }
 
   describe '#connect' do
     before { allow(broker).to receive(:set_up_amqp_connection) }
@@ -195,7 +203,7 @@ describe Hutch::Broker do
       after  { broker.disconnect }
 
       describe '#api_client' do
-        subject { super().api_client }
+        subject { broker.api_client }
         it { is_expected.to be_a CarrotTop }
       end
     end

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -9,6 +9,10 @@ describe Hutch::Config do
     Hutch::Config.initialize
   end
 
+  after do
+    Hutch::Config.instance_variable_set(:@config, nil)
+  end
+
   describe '.get' do
     context 'for valid attributes' do
       subject { Hutch::Config.get(:mq_host) }
@@ -19,9 +23,7 @@ describe Hutch::Config do
 
       context 'with an overridden value' do
         before do
-          allow(Hutch::Config).to receive_messages(
-            user_config: { mq_host: new_value }
-          )
+          Hutch::Config.set(:mq_host, new_value)
         end
 
         it { is_expected.to eq(new_value) }

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -5,6 +5,7 @@ describe Hutch::Config do
   let(:new_value) { 'not-localhost' }
 
   before do
+    Hutch::Config.instance_variable_set(:@config, nil)
     Hutch::Config.initialize
   end
 
@@ -166,6 +167,19 @@ YAML
     it 'will accept strings and symbols as config keys' do
       expect(Hutch::Config.get(:mq_host)).to eq '127.0.0.1'
       expect(Hutch::Config.get('mq_host')).to eq '127.0.0.1'
+    end
+
+    describe 'it will not overwrite existing config' do
+      it 'with defaults' do
+        expect(Hutch::Config.get(:mq_host)).to eq '127.0.0.1'
+        Hutch::Config.initialize
+
+        Hutch::Config.set(:mq_host, 'example2.com')
+
+        expect(Hutch::Config.get(:mq_host)).to eq 'example2.com'
+        Hutch::Config.initialize
+        expect(Hutch::Config.get(:mq_host)).to eq 'example2.com'
+      end
     end
   end
 end


### PR DESCRIPTION
Config.initialize can be run again and again, not losing settings.

Question: That unprotected `@config.merge!(params)` - should it go via existing setters?

See #233 