### PR TITLE
Worker: Remove unused constant

### DIFF
--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -9,8 +9,6 @@ module Hutch
   class Worker
     include Logging
 
-    SHUTDOWN_SIGNALS = %w(QUIT TERM INT)
-
     def initialize(broker, consumers, setup_procs)
       @broker        = broker
       self.consumers = consumers


### PR DESCRIPTION
In #236 it became clear to me that this other same-name constant `SHUTDOWN_SIGNALS` was not seeing any use in Worker. (Waiter has the right one.)

This PR removes it.