### PR TITLE
Allows to pass all message properties to error handlers.

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.11.2'
-  gem.add_runtime_dependency 'activesupport', '>= 3.0'
+  gem.add_runtime_dependency 'activesupport', '~> 4.0'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'yard', '~> 0.8'

--- a/lib/hutch/error_handlers/airbrake.rb
+++ b/lib/hutch/error_handlers/airbrake.rb
@@ -6,7 +6,8 @@ module Hutch
     class Airbrake
       include Logging
 
-      def handle(message_id, payload, consumer, ex)
+      def handle(properties, payload, consumer, ex)
+        message_id = properties.message_id
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Airbrake"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -6,7 +6,8 @@ module Hutch
     class Honeybadger
       include Logging
 
-      def handle(message_id, payload, consumer, ex)
+      def handle(properties, payload, consumer, ex)
+        message_id = properties.message_id
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Honeybadger"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/error_handlers/logger.rb
+++ b/lib/hutch/error_handlers/logger.rb
@@ -5,7 +5,8 @@ module Hutch
     class Logger
       include Logging
 
-      def handle(message_id, payload, consumer, ex)
+      def handle(properties, payload, consumer, ex)
+        message_id = properties.message_id
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "error in consumer '#{consumer}'"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -12,7 +12,8 @@ module Hutch
         end
       end
 
-      def handle(message_id, payload, consumer, ex)
+      def handle(properties, payload, consumer, ex)
+        message_id = properties.message_id
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Sentry"
         logger.error prefix + "#{ex.class} - #{ex.message}"

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -68,16 +68,16 @@ module Hutch
       @broker.ack(delivery_info.delivery_tag)
     rescue => ex
       acknowledge_error(delivery_info, properties, @broker, ex)
-      handle_error(properties.message_id, payload, consumer, ex)
+      handle_error(properties, payload, consumer, ex)
     end
 
     def with_tracing(klass)
       Hutch::Config[:tracer].new(klass)
     end
 
-    def handle_error(message_id, payload, consumer, ex)
+    def handle_error(*args)
       Hutch::Config[:error_handlers].each do |backend|
-        backend.handle(message_id, payload, consumer, ex)
+        backend.handle(*args)
       end
     end
 

--- a/spec/hutch/error_handlers/airbrake_spec.rb
+++ b/spec/hutch/error_handlers/airbrake_spec.rb
@@ -14,6 +14,7 @@ describe Hutch::ErrorHandlers::Airbrake do
 
     it "logs the error to Airbrake" do
       message_id = "1"
+      properties = OpenStruct.new(message_id: message_id)
       payload = "{}"
       consumer = double
       ex = error
@@ -28,7 +29,7 @@ describe Hutch::ErrorHandlers::Airbrake do
         :cgi_data => ENV.to_hash,
       }
       expect(::Airbrake).to receive(:notify_or_ignore).with(ex, message)
-      error_handler.handle(message_id, payload, consumer, ex)
+      error_handler.handle(properties, payload, consumer, ex)
     end
   end
 end

--- a/spec/hutch/error_handlers/honeybadger_spec.rb
+++ b/spec/hutch/error_handlers/honeybadger_spec.rb
@@ -14,6 +14,7 @@ describe Hutch::ErrorHandlers::Honeybadger do
 
     it "logs the error to Honeybadger" do
       message_id = "1"
+      properties = OpenStruct.new(message_id: message_id)
       payload = "{}"
       consumer = double
       ex = error
@@ -30,7 +31,7 @@ describe Hutch::ErrorHandlers::Honeybadger do
           }
       }
       expect(::Honeybadger).to receive(:notify_or_ignore).with(message)
-      error_handler.handle(message_id, payload, consumer, ex)
+      error_handler.handle(properties, payload, consumer, ex)
     end
   end
 end

--- a/spec/hutch/error_handlers/logger_spec.rb
+++ b/spec/hutch/error_handlers/logger_spec.rb
@@ -4,12 +4,14 @@ describe Hutch::ErrorHandlers::Logger do
   let(:error_handler) { Hutch::ErrorHandlers::Logger.new }
 
   describe '#handle' do
+    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:payload) { "{}" }
     let(:error) { double(message: "Stuff went wrong", class: "RuntimeError",
                        backtrace: ["line 1", "line 2"]) }
 
     it "logs three separate lines" do
       expect(Hutch::Logging.logger).to receive(:error).exactly(3).times
-      error_handler.handle("1", "{}", double, error)
+      error_handler.handle(properties, payload, double, error)
     end
   end
 end

--- a/spec/hutch/error_handlers/sentry_spec.rb
+++ b/spec/hutch/error_handlers/sentry_spec.rb
@@ -4,6 +4,8 @@ describe Hutch::ErrorHandlers::Sentry do
   let(:error_handler) { Hutch::ErrorHandlers::Sentry.new }
 
   describe '#handle' do
+    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:payload) { "{}" }
     let(:error) do
       begin
         raise "Stuff went wrong"
@@ -13,8 +15,8 @@ describe Hutch::ErrorHandlers::Sentry do
     end
 
     it "logs the error to Sentry" do
-      expect(Raven).to receive(:capture_exception).with(error, extra: { payload: "{}" })
-      error_handler.handle("1", "{}", double, error)
+      expect(Raven).to receive(:capture_exception).with(error, extra: { payload: payload })
+      error_handler.handle(properties, payload, double, error)
     end
   end
 end


### PR DESCRIPTION
Message properties can include valuable message informations such as
correlation id, message type, app specific headers and many more.
When handling consumer process errors, we should be able to make decisions
based on any message properties.

Note: This is a breaking change in case people created their own error handlers.