### PR TITLE
Set required Ruby version

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.description = 'Hutch is a Ruby library for enabling asynchronous ' +
                     'inter-service communication using RabbitMQ.'
   gem.version = Hutch::VERSION.dup
+  gem.required_ruby_version = '>= 2.0'
   gem.authors = ['Harry Marr']
   gem.email = ['developers@gocardless.com']
   gem.homepage = 'https://github.com/gocardless/hutch'


### PR DESCRIPTION
💁  The dependencies of this gem require a modern version of Ruby (see the following stderr output).

Specifying the required Ruby version in the configuration should help consumers using deprecated Rubies by failing fast during `gem install`, rather than during `bundle install`.

```
Gem::InstallError: amq-protocol requires Ruby version >= 2.0.

Gem::InstallError: mime-types-data requires Ruby version >= 2.0.

Gem::InstallError: tins requires Ruby version >= 2.0.
```