### PR TITLE
Add an Opbeat error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Contributed by Pierre-Louis Gottfrois.
 
 GH issue: [hutch#238](https://github.com/gocardless/hutch/pull/238)
 
+### Opbeat Error Handler
+
+Contributed by Olle Jonsson.
+
 ## 0.22.1 — June 7th, 2016
 
 ### Message Payload is Reported to Sentry

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development, :test do
   gem "coveralls", require: false
   gem "newrelic_rpm"
   gem "airbrake", "~> 5.0"
+  gem "opbeat", "~> 3.0.9"
 end
 
 group :development, :darwin do

--- a/lib/hutch/error_handlers.rb
+++ b/lib/hutch/error_handlers.rb
@@ -4,5 +4,6 @@ module Hutch
     autoload :Sentry,      'hutch/error_handlers/sentry'
     autoload :Honeybadger, 'hutch/error_handlers/honeybadger'
     autoload :Airbrake,    'hutch/error_handlers/airbrake'
+    autoload :Opbeat,      'hutch/error_handlers/opbeat'
   end
 end

--- a/lib/hutch/error_handlers/opbeat.rb
+++ b/lib/hutch/error_handlers/opbeat.rb
@@ -1,0 +1,24 @@
+require 'hutch/logging'
+require 'opbeat'
+
+module Hutch
+  module ErrorHandlers
+    class Opbeat
+      include Logging
+
+      def initialize
+        unless ::Opbeat.respond_to?(:report)
+          raise "The Opbeat error handler requires Opbeat >= 3.0"
+        end
+      end
+
+      def handle(properties, payload, consumer, ex)
+        message_id = properties.message_id
+        prefix = "message(#{message_id || '-'}): "
+        logger.error prefix + "Logging event to Opbeat"
+        logger.error prefix + "#{ex.class} - #{ex.message}"
+        ::Opbeat.report(ex, extra: { payload: payload })
+      end
+    end
+  end
+end

--- a/spec/hutch/error_handlers/opbeat_spec.rb
+++ b/spec/hutch/error_handlers/opbeat_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-require 'hutch/error_handlers/opbeat'
-
 describe Hutch::ErrorHandlers::Opbeat do
   let(:error_handler) { Hutch::ErrorHandlers::Opbeat.new }
 

--- a/spec/hutch/error_handlers/opbeat_spec.rb
+++ b/spec/hutch/error_handlers/opbeat_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+require 'hutch/error_handlers/opbeat'
+
+describe Hutch::ErrorHandlers::Opbeat do
+  let(:error_handler) { Hutch::ErrorHandlers::Opbeat.new }
+
+  describe '#handle' do
+    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:payload) { "{}" }
+    let(:error) do
+      begin
+        raise "Stuff went wrong"
+      rescue RuntimeError => err
+        err
+      end
+    end
+
+    it "logs the error to Opbeat" do
+      expect(Opbeat).to receive(:report).with(error, extra: { payload: payload })
+      error_handler.handle(properties, payload, double, error)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an [Opbeat](https://github.com/opbeat/opbeat-ruby) error handler.

It needs trying out in my setting, but I'm using both Hutch and Opbeat, so it should be possible soon.