### PR TITLE
Better support for JRuby in Travis, tests, gemspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--order random

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - "2.2"
   - "2.1"
   - "2.0"
-  - "jruby-9.0.0.0"
+  - "jruby-9.1.5.0"
 
 env:
   JRUBY_OPTS: "--debug"
@@ -17,4 +17,4 @@ services:
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.0.0.0
+    - rvm: jruby-9.1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ services:
   - rabbitmq
 
 matrix:
-  exclude:
+  include:
     - rvm: 2.3.0
-      jdk: oraclejdk8
-    - rvm: 2.2
-      jdk: oraclejdk8
-    - rvm: 2.1
-      jdk: oraclejdk8
-    - rvm: 2.0
-      jdk: oraclejdk8
-    - rvm: jruby-9.1.5.0
       jdk: oraclejdk7
+    - rvm: 2.2
+      jdk: oraclejdk7
+    - rvm: 2.1
+      jdk: oraclejdk7
+    - rvm: 2.0
+      jdk: oraclejdk7
+    - rvm: jruby-9.1.5.0
+      jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - "2.0"
   - "jruby-9.1.5.0"
 
+jdk:
+  - oraclejdk8
+
 env:
   JRUBY_OPTS: "--debug"
 
@@ -15,7 +18,13 @@ sudo: false
 services:
   - rabbitmq
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+matrix:
+  exclude:
+    - rvm: 2.3.0
+      jdk: oraclejdk8
+    - rvm: 2.2
+      jdk: oraclejdk8
+    - rvm: 2.1
+      jdk: oraclejdk8
+    - rvm: 2.0
+      jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ sudo: false
 services:
   - rabbitmq
 
+matrix:
+  allow_failures:
+    - rvm: jruby-9.0.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - "jruby-9.1.5.0"
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 env:
@@ -18,16 +17,3 @@ sudo: false
 
 services:
   - rabbitmq
-
-matrix:
-  include:
-    - rvm: 2.3.0
-      jdk: oraclejdk7
-    - rvm: 2.2
-      jdk: oraclejdk7
-    - rvm: 2.1
-      jdk: oraclejdk7
-    - rvm: 2.0
-      jdk: oraclejdk7
-    - rvm: jruby-9.1.5.0
-      jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - "2.0"
   - "jruby-9.0.0.0"
 
+env:
+  JRUBY_OPTS: "--debug"
+
 sudo: false
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ sudo: false
 
 services:
   - rabbitmq
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk8
 
 env:
-  JRUBY_OPTS: "--debug"
+  - JRUBY_OPTS=--debug
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 language: ruby
 cache: bundler
-rvm:
-  - "2.3.0"
-  - "2.2"
-  - "2.1"
-  - "2.0"
-  - "jruby-9.1.5.0"
 
-jdk:
-  - oraclejdk8
-
-env:
-  - JRUBY_OPTS=--debug
-
-sudo: false
+matrix:
+  include:
+    - rvm: 2.3.0
+    - rvm: 2.2
+    - rvm: 2.1
+    - rvm: 2.0
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS='--debug'
+      jdk: oraclejdk8
 
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-
+before_install: gem i bundler
 matrix:
   include:
     - rvm: 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,3 @@ sudo: false
 
 services:
   - rabbitmq
-
-matrix:
-  allow_failures:
-    - rvm: jruby-9.1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ sudo: false
 services:
   - rabbitmq
 
-matrix:
-  allow_failures:
-    - rvm: jruby-9.0.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - "jruby-9.1.5.0"
 
 jdk:
+  - oraclejdk7
   - oraclejdk8
 
 env:
@@ -28,3 +29,5 @@ matrix:
       jdk: oraclejdk8
     - rvm: 2.0
       jdk: oraclejdk8
+    - rvm: jruby-9.1.5.0
+      jdk: oraclejdk7

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem "honeybadger"
   gem "coveralls", require: false
   gem "newrelic_rpm"
-  gem "airbrake", "~> 4.0"
+  gem "airbrake", "~> 5.0"
 end
 
 group :development, :darwin do

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activesupport', (RUBY_VERSION >= '2.3' ? '>= 4.0' : '~> 4.0')
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
-  gem.add_development_dependency 'yard', '~> 0.8'
-  gem.add_development_dependency 'redcarpet', '> 0'
+  gem.add_development_dependency 'yard', '~> 0.9'
+  gem.add_development_dependency 'redcarpet', '> 0' unless defined?(JRUBY_VERSION)
   gem.add_development_dependency 'github-markup', '> 0'
 
   gem.name = 'hutch'

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -14,7 +14,12 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'yard', '~> 0.9'
-  gem.add_development_dependency 'redcarpet', '> 0' unless defined?(JRUBY_VERSION)
+
+  if defined?(JRUBY_VERSION)
+    gem.add_development_dependency 'kramdown', '> 0'
+  else
+    gem.add_development_dependency 'redcarpet', '> 0'
+  end
   gem.add_development_dependency 'github-markup', '> 0'
 
   gem.name = 'hutch'

--- a/lib/hutch/error_handlers/airbrake.rb
+++ b/lib/hutch/error_handlers/airbrake.rb
@@ -11,16 +11,25 @@ module Hutch
         prefix = "message(#{message_id || '-'}): "
         logger.error prefix + "Logging event to Airbrake"
         logger.error prefix + "#{ex.class} - #{ex.message}"
-        ::Airbrake.notify_or_ignore(ex, {
-          :error_class => ex.class.name,
-          :error_message => "#{ ex.class.name }: #{ ex.message }",
-          :backtrace => ex.backtrace,
-          :parameters => {
-            :payload => payload,
-            :consumer => consumer,
-          },
-          :cgi_data => ENV.to_hash,
-        })
+
+        if ::Airbrake.respond_to?(:notify_or_ignore)
+          ::Airbrake.notify_or_ignore(ex, {
+            error_class: ex.class.name,
+            error_message: "#{ ex.class.name }: #{ ex.message }",
+            backtrace: ex.backtrace,
+            parameters: {
+              payload: payload,
+              consumer: consumer,
+            },
+            cgi_data: ENV.to_hash,
+          })
+        else
+          ::Airbrake.notify(ex, {
+            payload: payload,
+            consumer: consumer,
+            cgi_data: ENV.to_hash,
+          })
+        end
       end
     end
   end

--- a/spec/hutch/error_handlers/airbrake_spec.rb
+++ b/spec/hutch/error_handlers/airbrake_spec.rb
@@ -19,16 +19,11 @@ describe Hutch::ErrorHandlers::Airbrake do
       consumer = double
       ex = error
       message = {
-        :error_class => ex.class.name,
-        :error_message => "#{ ex.class.name }: #{ ex.message }",
-        :backtrace => ex.backtrace,
-        :parameters => {
-          :payload => payload,
-          :consumer => consumer,
-        },
-        :cgi_data => ENV.to_hash,
+        payload: payload,
+        consumer: consumer,
+        cgi_data: ENV.to_hash,
       }
-      expect(::Airbrake).to receive(:notify_or_ignore).with(ex, message)
+      expect(::Airbrake).to receive(:notify).with(ex, message)
       error_handler.handle(properties, payload, consumer, ex)
     end
   end

--- a/spec/hutch/waiter_spec.rb
+++ b/spec/hutch/waiter_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Hutch::Waiter do
     end
 
     described_class::SHUTDOWN_SIGNALS.each do |signal|
+      # JRuby does not support QUIT:
+      # The signal QUIT is in use by the JVM and will not work correctly on this platform
+      next if signal == 'QUIT' && defined?(JRUBY_VERSION)
+
       context "a #{signal} signal is received" do
         it "logs that hutch is stopping" do
           expect(Hutch::Logging.logger).to receive(:info)


### PR DESCRIPTION
On jruby-9k, we always fail on installing a development dependency which is used to generate documentation. Illustration: [Example failure to build](https://travis-ci.org/gocardless/hutch/jobs/161669440)

This PR improves things for JRuby:

- uses Kramdown for Markdown on JRuby
- skips using the QUIT signal in the tests, on the JRuby platform
- configures `JRUBY_OPTS=--debug` in builds
- removes JRuby from Travis' allowed_failures
- relies on latest published JRuby: jruby-9.1.5.0
- [has a fine explanation/theory on what could have caused a weird stacktrace](https://logs.jruby.org/jruby/2016-09-21)
- (and as a bonus round) upgrades the Airbrake error handler to its modern form (5.x)

Result:

- Travis builds on JRuby pass, and can publish test coverage data.
