### PR TITLE
Bump gem multi_json 1.12.1

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency 'bunny', '>= 2.5.0'
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
-  gem.add_runtime_dependency 'multi_json', '~> 1.11.2'
+  gem.add_runtime_dependency 'multi_json', '~> 1.12.1'
   gem.add_runtime_dependency 'activesupport', (RUBY_VERSION >= '2.3' ? '>= 4.0' : '~> 4.0')
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'


### PR DESCRIPTION
This PR updates the multi_json gem in the gemspec.

- [CHANGELOG](https://github.com/intridea/multi_json/blob/master/CHANGELOG.md)