### PR TITLE
Gemspec: Move development deps to Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 coverage
 .yardoc
 doc
+gemfiles/Gemfile.*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,18 @@ before_install: gem i bundler
 matrix:
   include:
     - rvm: 2.3.0
+      gemfile: gemfiles/Gemfile.activesupport5
     - rvm: 2.2
+      gemfile: gemfiles/Gemfile.activesupport4
     - rvm: 2.1
+      gemfile: gemfiles/Gemfile.activesupport4
     - rvm: 2.0
+      gemfile: gemfiles/Gemfile.activesupport4
     - rvm: jruby-9.1.5.0
-      env: JRUBY_OPTS='--debug'
       jdk: oraclejdk8
+      gemfile: gemfiles/Gemfile.activesupport5
+      env:
+        - JRUBY_OPTS='--debug'
 
 services:
   - rabbitmq

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,17 @@ group :development do
   gem "rake"
   gem "guard", "~> 2.14", platform: :mri_23
   gem "guard-rspec", "~> 4.7", platform: :mri_23
+
+  gem "yard", "~> 0.9"
+  gem 'kramdown', "> 0", platform: :jruby
+  gem "redcarpet", "> 0", platform: :mri
+  gem "github-markup", "> 0"
 end
 
 group :development, :test do
+  gem "rspec", "~> 3.0"
+  gem "simplecov", "~> 0.12"
+
   gem "sentry-raven"
   gem "honeybadger"
   gem "coveralls", "~> 0.8.15", require: false

--- a/gemfiles/Gemfile.activesupport4
+++ b/gemfiles/Gemfile.activesupport4
@@ -1,0 +1,2 @@
+eval_gemfile File.expand_path('../../Gemfile', __FILE__)
+gem 'activesupport', '~> 4.0'

--- a/gemfiles/Gemfile.activesupport5
+++ b/gemfiles/Gemfile.activesupport5
@@ -1,0 +1,2 @@
+eval_gemfile File.expand_path('../../Gemfile', __FILE__)
+gem 'activesupport', '>= 4.0'

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -10,17 +10,7 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.12.1'
-  gem.add_runtime_dependency 'activesupport', (RUBY_VERSION >= '2.3' ? '>= 4.0' : '~> 4.0')
-  gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'simplecov', '~> 0.12'
-  gem.add_development_dependency 'yard', '~> 0.9'
-
-  if defined?(JRUBY_VERSION)
-    gem.add_development_dependency 'kramdown', '> 0'
-  else
-    gem.add_development_dependency 'redcarpet', '> 0'
-  end
-  gem.add_development_dependency 'github-markup', '> 0'
+  gem.add_runtime_dependency 'activesupport'
 
   gem.name = 'hutch'
   gem.summary = 'Easy inter-service communication using RabbitMQ.'


### PR DESCRIPTION
This PR moves the development dependencies out of the gemspec and into groups in the Gemfile.

It also moves the version-dependent activesupport dependency into separated Gemfiles, so that the Travis build matrix targets can choose which activesupport version is for them.

By trying to leverage Bundler's `platform` support, we can get away from weird hacks in the gemspec.

In the Travis build matrix each Ruby version gets its dependencies pointed out to it using the `gemfile:` travis.yml feature. A `gemfiles/` folder is supplied.


