### PR TITLE
Gemfile: guard and guard-rspec work only on mri_23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 group :development do
   gem "rake"
-  gem "guard", "~> 2.14", platform: :mri
-  gem "guard-rspec", "~> 4.7", platform: :mri
+  gem "guard", "~> 2.14", platform: :mri_23
+  gem "guard-rspec", "~> 4.7", platform: :mri_23
 end
 
 group :development, :test do


### PR DESCRIPTION
This PR wants to fix master so that [guard](https://github.com/guard/guard) and guard-rspec do not disturb other Travis build targets