### PR TITLE
Extend readme with environment based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,20 @@ Known configuration parameters are:
  * `write_timeout`: Bunny's socket write timeout (default: `11`)
  * `tracer`: tracer to use to track message processing
 
+### Environment variables
+
+The file configuration options mentioned above can also be passed in via environment variables, using the `HUTCH_` prefix, eg.
+
+ * `connection_timeout` &rarr; `HUTCH_CONNECTION_TIMEOUT`.
+
+### Configuration precedence
+
+In order from lowest to highest precedence:
+
+0. Default values
+0. `HUTCH_*` environment variables
+0. Configuration file
+0. Explicit settings through `Hutch::Config.set`
 
 ## Supported RabbitMQ Versions
 


### PR DESCRIPTION
Environment based configuration is possible in `Hutch` but this was only apparent if someone took a look into `lib/hutch/config.rb`.

### Changes
This changeset updates the readme to mention the possibility of this and also provides a cheat sheet for the configuration preference order.

Easier to view changes: https://github.com/sldblog/hutch/blob/dl-update-configuration-readme/README.md#environment-variables