### PR TITLE
Style: prefer string interpolation, not concat

### DIFF
--- a/lib/hutch/error_handlers/airbrake.rb
+++ b/lib/hutch/error_handlers/airbrake.rb
@@ -8,9 +8,9 @@ module Hutch
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id
-        prefix = "message(#{message_id || '-'}): "
-        logger.error prefix + "Logging event to Airbrake"
-        logger.error prefix + "#{ex.class} - #{ex.message}"
+        prefix = "message(#{message_id || '-'}):"
+        logger.error "#{prefix} Logging event to Airbrake"
+        logger.error "#{prefix} #{ex.class} - #{ex.message}"
 
         if ::Airbrake.respond_to?(:notify_or_ignore)
           ::Airbrake.notify_or_ignore(ex, {

--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -8,9 +8,9 @@ module Hutch
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id
-        prefix = "message(#{message_id || '-'}): "
-        logger.error prefix + "Logging event to Honeybadger"
-        logger.error prefix + "#{ex.class} - #{ex.message}"
+        prefix = "message(#{message_id || '-'}):"
+        logger.error "#{prefix} Logging event to Honeybadger"
+        logger.error "#{prefix} #{ex.class} - #{ex.message}"
         ::Honeybadger.notify_or_ignore(
           :error_class => ex.class.name,
           :error_message => "#{ ex.class.name }: #{ ex.message }",

--- a/lib/hutch/error_handlers/logger.rb
+++ b/lib/hutch/error_handlers/logger.rb
@@ -7,9 +7,9 @@ module Hutch
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id
-        prefix = "message(#{message_id || '-'}): "
-        logger.error prefix + "error in consumer '#{consumer}'"
-        logger.error prefix + "#{ex.class} - #{ex.message}"
+        prefix = "message(#{message_id || '-'}):"
+        logger.error "#{prefix} error in consumer '#{consumer}'"
+        logger.error "#{prefix} #{ex.class} - #{ex.message}"
         logger.error (['backtrace:'] + ex.backtrace).join("\n")
       end
     end

--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -14,9 +14,9 @@ module Hutch
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id
-        prefix = "message(#{message_id || '-'}): "
-        logger.error prefix + "Logging event to Sentry"
-        logger.error prefix + "#{ex.class} - #{ex.message}"
+        prefix = "message(#{message_id || '-'}):"
+        logger.error "#{prefix} Logging event to Sentry"
+        logger.error "#{prefix} #{ex.class} - #{ex.message}"
         Raven.capture_exception(ex, extra: { payload: payload })
       end
     end


### PR DESCRIPTION
Trivial change to string interpolation in log messages in error handlers.

This is a follow-up PR to a previous change to the Opbeat error handler. See #257