### PR TITLE
Logging: remove redundant Hutch::Config.initialize

### DIFF
--- a/lib/hutch/logging.rb
+++ b/lib/hutch/logging.rb
@@ -9,12 +9,12 @@ module Hutch
       end
     end
 
-    def self.setup_logger(target = $stdout)
+    def self.setup_logger
       require 'hutch/config'
-      @logger = Logger.new(target)
-      @logger.level = Hutch::Config.log_level
-      @logger.formatter = HutchFormatter.new
-      @logger
+      @logger = Logger.new($stdout).tap do |l|
+        l.level = Hutch::Config.log_level
+        l.formatter = HutchFormatter.new
+      end
     end
 
     def self.logger

--- a/lib/hutch/logging.rb
+++ b/lib/hutch/logging.rb
@@ -11,7 +11,6 @@ module Hutch
 
     def self.setup_logger(target = $stdout)
       require 'hutch/config'
-      Hutch::Config.initialize
       @logger = Logger.new(target)
       @logger.level = Hutch::Config.log_level
       @logger.formatter = HutchFormatter.new


### PR DESCRIPTION
The last statement of the Config class is to run initialize. We don't need to do it twice.
