### PR TITLE
Add an Opbeat Tracer

### DIFF
--- a/lib/hutch/tracers.rb
+++ b/lib/hutch/tracers.rb
@@ -2,5 +2,6 @@ module Hutch
   module Tracers
     autoload :NullTracer, 'hutch/tracers/null_tracer'
     autoload :NewRelic,   'hutch/tracers/newrelic'
+    autoload :Opbeat,     'hutch/tracers/opbeat'
   end
 end

--- a/lib/hutch/tracers/opbeat.rb
+++ b/lib/hutch/tracers/opbeat.rb
@@ -1,0 +1,37 @@
+require 'opbeat'
+
+module Hutch
+  module Tracers
+    # Tracer for Opbeat, which traces each message processed.
+    class Opbeat
+      KIND = 'messaging.hutch'.freeze
+
+      # @param klass [Consumer] Consumer instance (!)
+      def initialize(klass)
+        @klass = klass
+      end
+
+      # @param message [Message]
+      def handle(message)
+        ::Opbeat.transaction(sig, KIND, extra: extra_from(message)) do
+          @klass.process(message)
+        end.done(true)
+      end
+
+      private
+
+      def sig
+        @klass.class.name
+      end
+
+      def extra_from(message)
+        {
+          body: message.body.to_s,
+          message_id: message.message_id,
+          timestamp: message.timestamp,
+          routing_key: message.routing_key
+        }
+      end
+    end
+  end
+end

--- a/spec/tracers/opbeat_spec.rb
+++ b/spec/tracers/opbeat_spec.rb
@@ -1,0 +1,44 @@
+require 'hutch/message'
+require 'hutch/serializers/identity'
+require 'hutch/tracers'
+
+RSpec.describe Hutch::Tracers::Opbeat do
+  let(:consumer) { double('the-consumer') }
+
+  subject(:tracer) { described_class.new(consumer) }
+
+  let(:message) do
+    Hutch::Message.new(double('the-delivery-info', routing_key: 'foo.bar',
+                                                   exchange: 'foo'),
+                       double('the-properties', message_id: 'the-id',
+                                                timestamp: 'the-time'),
+                       double('the-payload', to_s: 'the-body'),
+                       Hutch::Serializers::Identity)
+  end
+
+  it 'formats messages as extra information' do
+    expected_extra = {
+      body: 'the-body',
+      message_id: 'the-id',
+      timestamp: 'the-time',
+      routing_key: 'foo.bar'
+    }
+    expect(Opbeat).to receive(:transaction).with(anything,
+                                           'messaging.hutch',
+                                           extra: expected_extra) {
+                                             double('done-callback', done: true)
+                                           }
+
+    tracer.handle(message)
+  end
+
+  it 'presents consumer class name as Opbeat tracing signature' do
+    expect(Opbeat).to receive(:transaction).with(consumer.class.name,
+                                           'messaging.hutch',
+                                           anything) {
+                                             double('done-callback', done: true)
+                                           }
+
+    tracer.handle(message)
+  end
+end


### PR DESCRIPTION
This PR adds a new autoloaded Tracer implementation for Opbeat.

- [x] load it only if Opbeat is defined (this is taken care of just like newrelic_rpm is required in the file that is autoloaded)
- [x] ask @mikker if this is the way to use Opbeat.trace