### PR TITLE
Perform a VM-wide thread stack trace dump on USR2

### DIFF
--- a/lib/hutch/waiter.rb
+++ b/lib/hutch/waiter.rb
@@ -3,8 +3,12 @@ require 'hutch/logging'
 module Hutch
   class Waiter
     include Logging
-
+    
+    class SkipHere < Exception
+    end
+    
     SHUTDOWN_SIGNALS = %w(QUIT TERM INT).keep_if { |s| Signal.list.keys.include? s }.freeze
+    USER_SIGNALS = %w(USR1 USR2).keep_if { |s| Signal.list.keys.include?(s) }.freeze
 
     def self.wait_until_signaled
       new.wait_until_signaled
@@ -14,10 +18,20 @@ module Hutch
       self.sig_read, self.sig_write = IO.pipe
 
       register_signal_handlers
-      wait_for_signal
+      
+      begin
+        wait_for_signal
 
-      sig = sig_read.gets.strip.downcase
-      logger.info "caught sig#{sig}, stopping hutch..."
+        sig = sig_read.gets.strip.downcase
+        if USER_SIGNALS.include?(sig.upcase)
+          logger.info "FUN TIME! #{sig}"
+          raise SkipHere
+        else
+          logger.info "caught sig#{sig}, stopping hutch..."
+        end
+      rescue SkipHere
+        retry
+      end
     end
 
     private
@@ -29,7 +43,7 @@ module Hutch
     end
 
     def register_signal_handlers
-      SHUTDOWN_SIGNALS.each do |sig|
+      (SHUTDOWN_SIGNALS + USER_SIGNALS).each do |sig|
         # This needs to be reentrant, so we queue up signals to be handled
         # in the run loop, rather than acting on signals here
         trap(sig) do

--- a/lib/hutch/waiter.rb
+++ b/lib/hutch/waiter.rb
@@ -13,7 +13,8 @@ module Hutch
     end
 
     SHUTDOWN_SIGNALS = supported_signals_of(%w(QUIT TERM INT)).freeze
-    USER_SIGNALS = supported_signals_of(%w(TTIN USR1 USR2)).freeze
+    # We have chosen a JRuby-supported signal
+    USER_SIGNALS = supported_signals_of(%w(USR2)).freeze
     REGISTERED_SIGNALS = (SHUTDOWN_SIGNALS + USER_SIGNALS).freeze
 
     def self.wait_until_signaled
@@ -51,17 +52,15 @@ module Hutch
     # @raises ContinueProcessingSignals
     def handle_user_signal(sig)
       case sig
-      when 'TTIN' then handle_ttin
-      when 'USR1', 'USR2' then handle_user_defined_signals
-      else
-        raise "Assertion failed - unhandled signal: #{sig.inspect}"
+      when 'USR2' then handle_usr2
+      else raise "Assertion failed - unhandled signal: #{sig.inspect}"
       end
       raise ContinueProcessingSignals
     end
 
     private
 
-    def handle_ttin
+    def handle_usr2
       Thread.list.each do |thread|
         logger.warn "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
         if thread.backtrace
@@ -70,10 +69,6 @@ module Hutch
           logger.warn '<no backtrace available>'
         end
       end
-    end
-
-    def handle_user_defined_signals
-      logger.warn "SIG#{sig} noted. Continuing." # TODO: Find useful behavior
     end
 
     attr_accessor :sig_read, :sig_write

--- a/spec/hutch/waiter_spec.rb
+++ b/spec/hutch/waiter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hutch::Waiter do
       context "a #{signal} signal is received" do
         it "logs that hutch is stopping" do
           expect(Hutch::Logging.logger).to receive(:info)
-            .with("caught sig#{signal.downcase}, stopping hutch...")
+            .with("caught SIG#{signal}, stopping hutch...")
 
           start_kill_thread(signal)
           described_class.wait_until_signaled


### PR DESCRIPTION
This is a PR inspired by another project which had a neat section of signals to send to the worker, to have to do things, like "shed current work item, never to requeue it" or "print a debug backtrace".

### Inspiration

- [Kuryuk - Signals chapter of docs](http://kuyruk.readthedocs.io/en/latest/signals.html)
- [Mike Perham's Sidekiq's wiki on Signals](https://github.com/mperham/sidekiq/wiki/Signals)

### Questions

- What signals should the Worker process handle?
- Can you golf the control structure exception away? (See - this is me feeling safe enough here to publish some not-so-great code.)

### Proposed changes

- introduce a USR2 signal to print all the Threads' backtraces
- generally keep the signals uppercased