### PR TITLE
Gemfile with ruby version marker, instead of specific gemfiles/ files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,12 @@ cache: bundler
 before_install: gem i bundler
 matrix:
   include:
-    - rvm: 2.3.0
-      gemfile: gemfiles/Gemfile.activesupport5
+    - rvm: 2.3.2
     - rvm: 2.2
-      gemfile: gemfiles/Gemfile.activesupport4
     - rvm: 2.1
-      gemfile: gemfiles/Gemfile.activesupport4
     - rvm: 2.0
-      gemfile: gemfiles/Gemfile.activesupport4
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.1.6.0
       jdk: oraclejdk8
-      gemfile: gemfiles/Gemfile.activesupport5
       env:
         - JRUBY_OPTS='--debug'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby RUBY_VERSION
+
 gemspec
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 desc "Run an IRB session with Hutch pre-loaded"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 desc "Run an IRB session with Hutch pre-loaded"

--- a/gemfiles/Gemfile.activesupport4
+++ b/gemfiles/Gemfile.activesupport4
@@ -1,2 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'activesupport', '~> 4.0'

--- a/gemfiles/Gemfile.activesupport5
+++ b/gemfiles/Gemfile.activesupport5
@@ -1,2 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'activesupport', '>= 4.0'

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.12'
-  gem.add_runtime_dependency 'activesupport'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2', '< 6'
 
   gem.name = 'hutch'
   gem.summary = 'Easy inter-service communication using RabbitMQ.'
-  gem.description = 'Hutch is a Ruby library for enabling asynchronous ' +
+  gem.description = 'Hutch is a Ruby library for enabling asynchronous ' \
                     'inter-service communication using RabbitMQ.'
   gem.version = Hutch::VERSION.dup
   gem.required_ruby_version = '>= 2.0'


### PR DESCRIPTION
This PR changes the Gemfile for the project, to include the Bundler feature [`ruby RUBY_VERSION`](https://bundler.io/v1.13/man/gemfile.5.html#RUBY), so that Bundler can locate the right gems for the current Ruby version.

Current status: ~experimental~ This passes all Travis tests, and does the right thing.

- hutch.gemspec: Avoid concatenating a String by using line-continuation operator instead.