### PR TITLE
Configure consumer tag names/prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,11 @@ In order from lowest to highest precedence:
 
 ### Generated list of configuration options
 
+Generate with
+
+0. `yard doc lib/hutch/config.rb`
+0. Copy the _Configuration_ section from `doc/Hutch/Config.html` here, with the anchor tags stripped.
+
 <table border="1" class="settings" style="overflow:visible;">
   <thead>
     <tr>
@@ -593,6 +598,15 @@ In order from lowest to highest precedence:
       <td>Boolean</td>
       <td><tt>HUTCH_CONSUMER_POOL_ABORT_ON_EXCEPTION</tt></td>
       <td><p>Should Bunny's consumer work pool threads abort on exception.</p>
+</td>
+    </tr>
+
+    <tr>
+      <td><tt>consumer_tag_prefix</tt></td>
+      <td>hutch</td>
+      <td>String</td>
+      <td><tt>HUTCH_CONSUMER_TAG_PREFIX</tt></td>
+      <td><p>Prefix displayed on the consumers tags.</p>
 </td>
     </tr>
   

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -130,6 +130,9 @@ module Hutch
     # The option is ignored on JRuby.
     boolean_setting :consumer_pool_abort_on_exception, false
 
+    # Prefix displayed on the consumers tags.
+    string_setting :consumer_tag_prefix, 'hutch'
+
     # Set of all setting keys
     ALL_KEYS = @boolean_keys + @number_keys + @string_keys
 

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -4,6 +4,7 @@ require 'hutch/broker'
 require 'hutch/acknowledgements/nack_on_all_failures'
 require 'hutch/waiter'
 require 'carrot-top'
+require 'securerandom'
 
 module Hutch
   class Worker
@@ -44,7 +45,7 @@ module Hutch
       queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
       @broker.bind_queue(queue, consumer.routing_keys)
 
-      queue.subscribe(consumer_tag: consumer_tag(queue), manual_ack: true) do |*args|
+      queue.subscribe(consumer_tag: unique_consumer_tag, manual_ack: true) do |*args|
         delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
         handle_message(consumer, delivery_info, properties, payload)
       end
@@ -104,9 +105,10 @@ module Hutch
 
     attr_accessor :setup_procs
 
-    def consumer_tag(queue)
+    def unique_consumer_tag
       prefix = Hutch::Config[:consumer_tag_prefix]
-      queue.channel.generate_consumer_tag(prefix)
+      unique_part = SecureRandom.uuid
+      "#{prefix}-#{unique_part}"
     end
   end
 end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -44,7 +44,7 @@ module Hutch
       queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
       @broker.bind_queue(queue, consumer.routing_keys)
 
-      queue.subscribe(manual_ack: true) do |*args|
+      queue.subscribe(consumer_tag: consumer_tag(queue), manual_ack: true) do |*args|
         delivery_info, properties, payload = Hutch::Adapter.decode_message(*args)
         handle_message(consumer, delivery_info, properties, payload)
       end
@@ -103,5 +103,10 @@ module Hutch
     private
 
     attr_accessor :setup_procs
+
+    def consumer_tag(queue)
+      prefix = Hutch::Config[:consumer_tag_prefix]
+      queue.channel.generate_consumer_tag(prefix)
+    end
   end
 end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -108,7 +108,9 @@ module Hutch
     def unique_consumer_tag
       prefix = Hutch::Config[:consumer_tag_prefix]
       unique_part = SecureRandom.uuid
-      "#{prefix}-#{unique_part}"
+      "#{prefix}-#{unique_part}".tap do |tag|
+        raise "Tag must be 255 bytes long at most, current one is #{tag.bytesize} ('#{tag}')" if tag.bytesize > 255
+      end
     end
   end
 end

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 require 'hutch/worker'
-require 'bunny/channel'
-require 'bunny/queue'
 
 describe Hutch::Worker do
   let(:consumer) { double('Consumer', routing_keys: %w( a b c ),
@@ -33,12 +31,8 @@ describe Hutch::Worker do
   end
 
   describe '#setup_queue' do
-    let(:queue) { instance_double(Bunny::Queue, bind: nil, subscribe: nil, channel: channel) }
-    let(:channel) { instance_double(Bunny::Channel) }
-    before do
-      allow(broker).to receive_messages(queue: queue, bind_queue: nil)
-      allow(channel).to receive(:generate_consumer_tag).with('hutch').and_return('hutch-random-tag')
-    end
+    let(:queue) { double('Queue', bind: nil, subscribe: nil) }
+    before { allow(broker).to receive_messages(queue: queue, bind_queue: nil) }
 
     it 'creates a queue' do
       expect(broker).to receive(:queue).with(consumer.get_queue_name, consumer.get_arguments).and_return(queue)
@@ -51,15 +45,14 @@ describe Hutch::Worker do
     end
 
     it 'sets up a subscription' do
-      expect(queue).to receive(:subscribe).with(consumer_tag: 'hutch-random-tag', manual_ack: true)
+      expect(queue).to receive(:subscribe).with(consumer_tag: %r(^hutch\-.{36}$), manual_ack: true)
       worker.setup_queue(consumer)
     end
 
     context 'with a configured consumer tag prefix' do
       it 'sets up a subscription with the configured tag prefix' do
         Hutch::Config.set(:consumer_tag_prefix, 'appname')
-        expect(channel).to receive(:generate_consumer_tag).with('appname').and_return('appname-random-tag')
-        expect(queue).to receive(:subscribe).with(consumer_tag: 'appname-random-tag', manual_ack: true)
+        expect(queue).to receive(:subscribe).with(consumer_tag: %r(^appname\-.{36}$), manual_ack: true)
         worker.setup_queue(consumer)
       end
     end


### PR DESCRIPTION
Allows us to configure the consumer names (tags) that are visible in RabbitMQ.

Tagging with specific names is useful for us because we have over 100 queues and lots of applications communicating. If we aim to be easily identifiable, we can do these things:

- define a routing key convention that refers to the application publishing the message
- define a queue name convention that identifies the consumers
- identify consumers by tag names

Out of the above three we cannot do the last one. So this changeset enables that configuration :)

### Notes

The default tag name changes from `bunny` to `hutch` with this change.

### Bonus

Explains on how to (still manually) update the generated configuration section in the readme.