### PR TITLE
Expose uri as normal config setting, so it can be used in ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,15 @@ Generate with
     </tr>
   
     <tr>
+      <td><tt>uri</tt></td>
+      <td>nil</td>
+      <td>String</td>
+      <td><tt>HUTCH_URI</tt></td>
+      <td><p>RabbitMQ URI (takes precedence over MQ username, password, host, port and vhost settings)</p>
+</td>
+    </tr>
+  
+    <tr>
       <td><tt>mq_api_host</tt></td>
       <td>127.0.0.1</td>
       <td>String</td>

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -60,6 +60,9 @@ module Hutch
     # RabbitMQ password
     string_setting :mq_password, 'guest'
 
+    # RabbitMQ uri
+    string_setting :uri, nil
+
     # RabbitMQ HTTP API hostname
     string_setting :mq_api_host, '127.0.0.1'
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -60,7 +60,7 @@ module Hutch
     # RabbitMQ password
     string_setting :mq_password, 'guest'
 
-    # RabbitMQ uri
+    # RabbitMQ URI (takes precedence over MQ username, password, host, port and vhost settings)
     string_setting :uri, nil
 
     # RabbitMQ HTTP API hostname


### PR DESCRIPTION
Note, I see in the logs that this shouldn't be used from the CLI, but I see that the CLI class is manually processing it's options so this work happen as a result of this.

Also updates the readme to show the URI option (via yard generation).

Fixes #269.