### PR TITLE
Travis: Add 2.4.0, use jruby-9.1.7.0; don't trap QUIT on JRuby since it's not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ cache: bundler
 before_install: gem i bundler
 matrix:
   include:
+    - rvm: 2.4.0
     - rvm: 2.3.3
     - rvm: 2.2
     - rvm: 2.1
     - rvm: 2.0
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS='--debug'

--- a/lib/hutch/waiter.rb
+++ b/lib/hutch/waiter.rb
@@ -12,7 +12,9 @@ module Hutch
     end
 
     def self.supported_signals_of(list)
-      list.keep_if { |s| Signal.list.keys.include? s }
+      list.keep_if { |s| Signal.list.keys.include?(s) }.tap do |result|
+        result.delete('QUIT') if defined?(JRUBY_VERSION)
+      end
     end
 
     SHUTDOWN_SIGNALS = supported_signals_of(%w(QUIT TERM INT)).freeze


### PR DESCRIPTION
This PR

- adds 2.4.0 to the build matrix
- updates to latest JRuby