### PR TITLE
Travis: Rubygems update in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
-before_install: gem i bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 matrix:
   include:
     - rvm: 2.4.0


### PR DESCRIPTION
While investigating if it would be possible to remove the `ruby RUBY_VERSION` marker in the Gemfile, I noted that we don't upgrade Rubygems before using it.

Do we want to?