### PR TITLE
Wrap API of error handler for Honeybadger

### DIFF
--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -27,7 +27,7 @@ module Hutch
         if ::Honeybadger.respond_to?(:notify_or_ignore)
           ::Honeybadger.notify_or_ignore(message)
         else
-          ::Honeybadger.notify(message, force: true)
+          ::Honeybadger.notify(message.merge(force: true))
         end
       end
     end

--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -3,6 +3,7 @@ require 'honeybadger'
 
 module Hutch
   module ErrorHandlers
+    # Error handler for the Honeybadger.io service
     class Honeybadger
       include Logging
 
@@ -11,18 +12,23 @@ module Hutch
         prefix = "message(#{message_id || '-'}):"
         logger.error "#{prefix} Logging event to Honeybadger"
         logger.error "#{prefix} #{ex.class} - #{ex.message}"
-        ::Honeybadger.notify_or_ignore(
-          :error_class => ex.class.name,
-          :error_message => "#{ ex.class.name }: #{ ex.message }",
-          :backtrace => ex.backtrace,
-          :context => {
-            :message_id => message_id,
-            :consumer => consumer
-          },
-          :parameters => {
-            :payload => payload
-          }
-        )
+        notify_honeybadger(error_class: ex.class.name,
+                           error_message: "#{ex.class.name}: #{ex.message}",
+                           backtrace: ex.backtrace,
+                           context: { message_id: message_id,
+                                      consumer: consumer },
+                           parameters: { payload: payload })
+      end
+
+      # Wrap API to support 3.0.0+
+      #
+      # @see https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md#300---2017-02-06
+      def notify_honeybadger(message)
+        if ::Honeybadger.respond_to?(:notify_or_ignore)
+          ::Honeybadger.notify_or_ignore(message)
+        else
+          ::Honeybadger.notify(message, force: true)
+        end
       end
     end
   end

--- a/spec/hutch/error_handlers/honeybadger_spec.rb
+++ b/spec/hutch/error_handlers/honeybadger_spec.rb
@@ -30,7 +30,7 @@ describe Hutch::ErrorHandlers::Honeybadger do
             :payload => payload
           }
       }
-      expect(::Honeybadger).to receive(:notify_or_ignore).with(message)
+      expect(error_handler).to receive(:notify_honeybadger).with(message)
       error_handler.handle(properties, payload, consumer, ex)
     end
   end


### PR DESCRIPTION
The API method used is [removed in the upstream 3.0.0](https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md#300---2017-02-06), which was just released (two, three weeks ago).

I read [the new method's docs](http://www.rubydoc.info/gems/honeybadger/Honeybadger%3Anotify) again, and noted that if the first arg is a Hash, then it's just 1 argument.