### PR TITLE
Travis: use jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: 2.2
     - rvm: 2.1
     - rvm: 2.0
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.8.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS='--debug'


### PR DESCRIPTION
This PR updates Travis' jruby to latest stable.