### PR TITLE
Fix a link to topic exchange docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ AMQP.connect(host: config[:host]) do |connection|
 end
 ```
 
-If using publisher confirms with amqp gem, see [this issue][pc-issue]
-and [this gist][pc-gist] for more info.
+If using publisher confirms with amqp gem, see [this issue](https://github.com/ruby-amqp/amqp/issues/92)
+and [this gist](https://gist.github.com/3042381) for more info.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ message[:id]  # => "02ABCXYZ"
 To subscribe to a topic, pass a routing key to `consume` in the class
 definition. To bind to multiple routing keys, simply pass extra routing keys
 in as additional arguments. Refer to the [RabbitMQ docs on topic exchanges
-][topic-docs] for more information about how to use routing keys. Here's an
-example consumer:
+](http://www.rabbitmq.com/tutorials/tutorial-five-ruby.html) for more information
+about how to use routing keys. Here's an example consumer:
 
 ```ruby
 class FailedPaymentConsumer


### PR DESCRIPTION
Just a quick fix while reading your docs