### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: 2.2.7
     - rvm: 2.1
     - rvm: 2.0
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS='--debug'


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.