### PR TITLE
[docs] Fix YARD annotation

### DIFF
--- a/lib/hutch/waiter.rb
+++ b/lib/hutch/waiter.rb
@@ -50,7 +50,7 @@ module Hutch
       end
     end
 
-    # @raises ContinueProcessingSignals
+    # @raise ContinueProcessingSignals
     def handle_user_signal(sig)
       case sig
       when 'USR2' then log_thread_backtraces


### PR DESCRIPTION
This PR fixes a very small detail: the YARD directive for "this raises an exception".

I used the yard-junk gem to find it. It worked.