### PR TITLE
Honey badger notify no force

### DIFF
--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -27,7 +27,7 @@ module Hutch
         if ::Honeybadger.respond_to?(:notify_or_ignore)
           ::Honeybadger.notify_or_ignore(message)
         else
-          ::Honeybadger.notify(message.merge(force: true))
+          ::Honeybadger.notify(message)
         end
       end
     end


### PR DESCRIPTION
#274 wraps the Honeybadger API to use `notify` after the removal of `notify_or_ignore`. By default, `notify` behaves the same, ignoring notices based on configuration. With the `force` option set to `true`, this is changed to notify regardless of whether the notice was configured to be ignored.

Hence, I'm removing the `force` option to restore previous behaviour.