### PR TITLE
Travis: Update Rubies in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ before_install:
   - gem install bundler
 matrix:
   include:
-    - rvm: 2.4.1
-    - rvm: 2.3.4
-    - rvm: 2.2.7
+    - rvm: 2.4.2
+    - rvm: 2.3.5
+    - rvm: 2.2.8
     - rvm: 2.1
     - rvm: 2.0
     - rvm: jruby-9.1.13.0


### PR DESCRIPTION
This PR uses ruby 2.4.2, 2.3.5, 2.2.8 in the build matrix, as soon as `rvm` supports it.