### PR TITLE
Group consumers

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -189,6 +189,10 @@ module Hutch
           Hutch::Config.pidfile = pidfile
         end
 
+        opts.on('--group GROUP', 'Consumer Group') do |group|
+          Hutch::Config.group = group
+        end
+
         opts.on('--version', 'Print the version and exit') do
           puts "hutch v#{VERSION}"
           exit 0

--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -189,7 +189,7 @@ module Hutch
           Hutch::Config.pidfile = pidfile
         end
 
-        opts.on('--group GROUP', 'Consumer Group') do |group|
+        opts.on('--only-group GROUP', 'Consumer Group') do |group|
           Hutch::Config.group = group
         end
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -136,6 +136,8 @@ module Hutch
     # Prefix displayed on the consumers tags.
     string_setting :consumer_tag_prefix, 'hutch'
 
+    string_setting :group, ''
+
     # Set of all setting keys
     ALL_KEYS = @boolean_keys + @number_keys + @string_keys
 
@@ -167,6 +169,7 @@ module Hutch
         # that will fall back to "nack unconditionally"
         error_acknowledgements: [],
         setup_procs: [],
+        consumers_groups: {},
         tracer: Hutch::Tracers::NullTracer,
         namespace: nil,
         pidfile: nil,

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -36,12 +36,18 @@ module Hutch
     # Set up the queues for each of the worker's consumers.
     def setup_queues
       logger.info 'setting up queues'
-      @consumers.each { |consumer| setup_queue(consumer) }
+      @consumers.each do |consumer|
+        next if group_configured? && group_restrict?(consumer)
+
+        setup_queue(consumer)
+      end
     end
 
     # Bind a consumer's routing keys to its queue, and set up a subscription to
     # receive messages sent to the queue.
     def setup_queue(consumer)
+      logger.info "setting up queue: #{consumer.get_queue_name}"
+
       queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
       @broker.bind_queue(queue, consumer.routing_keys)
 
@@ -102,6 +108,26 @@ module Hutch
     end
 
     private
+
+    def group_configured?
+      if consumers_groups.blank? && group.present?
+        logger.warn 'Consumer groups were not set up.'
+      end
+      group.present?
+    end
+
+    def group_restrict?(consumer)
+      allowed_consumers = consumers_groups[group]
+      allowed_consumers ? allowed_consumers.include?(consumer.name) : true
+    end
+
+    def group
+      Hutch::Config[:group]
+    end
+
+    def consumers_groups
+      Hutch::Config[:consumers_groups]
+    end
 
     attr_accessor :setup_procs
 

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -118,7 +118,7 @@ module Hutch
 
     def group_restrict?(consumer)
       allowed_consumers = consumers_groups[group]
-      allowed_consumers ? allowed_consumers.include?(consumer.name) : true
+      allowed_consumers ? !allowed_consumers.include?(consumer.name) : true
     end
 
     def group

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -110,8 +110,8 @@ module Hutch
     private
 
     def group_configured?
-      if consumers_groups.blank? && group.present?
-        logger.warn 'Consumer groups were not set up.'
+      if group.present? && consumers_groups.blank?
+        logger.warn 'Consumers\' groups were not set up.'
       end
       group.present?
     end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -37,7 +37,7 @@ module Hutch
     def setup_queues
       logger.info 'setting up queues'
       @consumers.each do |consumer|
-        next if group_configured? && group_restrict?(consumer)
+        next if group_configured? && group_restricted?(consumer)
 
         setup_queue(consumer)
       end
@@ -116,7 +116,7 @@ module Hutch
       group.present?
     end
 
-    def group_restrict?(consumer)
+    def group_restricted?(consumer)
       allowed_consumers = consumers_groups[group]
       allowed_consumers ? !allowed_consumers.include?(consumer.name) : true
     end


### PR DESCRIPTION
In case you use hutch with rails and you no need to run all consumers. Or if you need to split then into groups to balance load. Then define groups in config file:

``` yml
consumers_groups:
  payments:
    - DepositConsumer
    - CashoutConsumer
  notification:
    - EmailNotificationConsumer
```

and run ``` hutch --only-group=payments --config=CONFIG_PATH```