### PR TITLE
Report connection errors to sentry

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -90,6 +90,12 @@ module Hutch
       @worker.run
       :success
     rescue ConnectionError, AuthenticationError, WorkerSetupError => ex
+      dummy_props = Class.new do
+        attr_accessor :message_id
+      end
+      Hutch::Config[:error_handlers].each do |backend|
+       backend.handle(dummy_props.new, {}, nil, ex)
+      end
       logger.fatal ex.message
       :error
     end


### PR DESCRIPTION
When the hutch runner fails due to a connection, authentication or worker
setup error, the exception is only logged.

With this change the exception is also reported to sentry, if sentry is
available.

Closes #288