### PR TITLE
Add error handler class

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -90,6 +90,9 @@ module Hutch
       @worker.run
       :success
     rescue ConnectionError, AuthenticationError, WorkerSetupError => ex
+      Hutch::Config[:error_handlers].each do |backend|
+        backend.handle_setup_exception(ex)
+      end
       logger.fatal ex.message
       :error
     end

--- a/lib/hutch/error_handlers/airbrake.rb
+++ b/lib/hutch/error_handlers/airbrake.rb
@@ -1,10 +1,10 @@
 require 'hutch/logging'
 require 'airbrake'
+require 'hutch/error_handlers/base'
 
 module Hutch
   module ErrorHandlers
-    class Airbrake
-      include Logging
+    class Airbrake < Base
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id

--- a/lib/hutch/error_handlers/airbrake.rb
+++ b/lib/hutch/error_handlers/airbrake.rb
@@ -31,6 +31,24 @@ module Hutch
           })
         end
       end
+
+      def handle_setup_exception(ex)
+        logger.error "Logging setup exception to Airbrake"
+        logger.error "#{ex.class} - #{ex.message}"
+
+        if ::Airbrake.respond_to?(:notify_or_ignore)
+          ::Airbrake.notify_or_ignore(ex, {
+            error_class: ex.class.name,
+            error_message: "#{ ex.class.name }: #{ ex.message }",
+            backtrace: ex.backtrace,
+            cgi_data: ENV.to_hash,
+          })
+        else
+          ::Airbrake.notify(ex, {
+            cgi_data: ENV.to_hash,
+          })
+        end
+      end
     end
   end
 end

--- a/lib/hutch/error_handlers/base.rb
+++ b/lib/hutch/error_handlers/base.rb
@@ -1,0 +1,15 @@
+module Hutch
+  module ErrorHandlers
+    class Base
+      include Logging
+
+      def handle(properties, payload, consumer, ex)
+        raise NotImplementedError.new
+      end
+
+      def handle_setup_exception(ex)
+        raise NotImplementedError.new
+      end
+    end
+  end
+end

--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -1,11 +1,11 @@
 require 'hutch/logging'
 require 'honeybadger'
+require 'hutch/error_handlers/base'
 
 module Hutch
   module ErrorHandlers
     # Error handler for the Honeybadger.io service
-    class Honeybadger
-      include Logging
+    class Honeybadger < Base
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id

--- a/lib/hutch/error_handlers/honeybadger.rb
+++ b/lib/hutch/error_handlers/honeybadger.rb
@@ -20,6 +20,14 @@ module Hutch
                            parameters: { payload: payload })
       end
 
+      def handle_setup_exception(ex)
+        logger.error "Logging setup exception to Honeybadger"
+        logger.error "#{ex.class} - #{ex.message}"
+        notify_honeybadger(error_class: ex.class.name,
+                           error_message: "#{ex.class.name}: #{ex.message}",
+                           backtrace: ex.backtrace)
+      end
+
       # Wrap API to support 3.0.0+
       #
       # @see https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md#300---2017-02-06

--- a/lib/hutch/error_handlers/logger.rb
+++ b/lib/hutch/error_handlers/logger.rb
@@ -1,9 +1,9 @@
 require 'hutch/logging'
+require 'hutch/error_handlers/base'
 
 module Hutch
   module ErrorHandlers
-    class Logger
-      include Logging
+    class Logger < ErrorHandlers::Base
 
       def handle(properties, payload, consumer, ex)
         message_id = properties.message_id

--- a/lib/hutch/error_handlers/logger.rb
+++ b/lib/hutch/error_handlers/logger.rb
@@ -12,6 +12,11 @@ module Hutch
         logger.error "#{prefix} #{ex.class} - #{ex.message}"
         logger.error (['backtrace:'] + ex.backtrace).join("\n")
       end
+
+      def handle_setup_exception(ex)
+        logger.error "#{ex.class} - #{ex.message}"
+        logger.error (['backtrace:'] + ex.backtrace).join("\n")
+      end
     end
   end
 end

--- a/lib/hutch/error_handlers/opbeat.rb
+++ b/lib/hutch/error_handlers/opbeat.rb
@@ -1,10 +1,10 @@
 require 'hutch/logging'
 require 'opbeat'
+require 'hutch/error_handlers/base'
 
 module Hutch
   module ErrorHandlers
-    class Opbeat
-      include Logging
+    class Opbeat < Base
 
       def initialize
         unless ::Opbeat.respond_to?(:report)

--- a/lib/hutch/error_handlers/opbeat.rb
+++ b/lib/hutch/error_handlers/opbeat.rb
@@ -19,6 +19,12 @@ module Hutch
         logger.error "#{prefix} #{ex.class} - #{ex.message}"
         ::Opbeat.report(ex, extra: { payload: payload })
       end
+
+      def handle_setup_exception(ex)
+        logger.error "Logging setup exception to Opbeat"
+        logger.error "#{ex.class} - #{ex.message}"
+        ::Opbeat.report(ex)
+      end
     end
   end
 end

--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -19,6 +19,13 @@ module Hutch
         logger.error "#{prefix} #{ex.class} - #{ex.message}"
         Raven.capture_exception(ex, extra: { payload: payload })
       end
+
+      def handle_setup_exception(ex)
+        logger.error "Logging setup exception to Sentry"
+        logger.error "#{ex.class} - #{ex.message}"
+        Raven.capture_exception(ex)
+      end
+
     end
   end
 end

--- a/lib/hutch/error_handlers/sentry.rb
+++ b/lib/hutch/error_handlers/sentry.rb
@@ -1,10 +1,10 @@
 require 'hutch/logging'
 require 'raven'
+require 'hutch/error_handlers/base'
 
 module Hutch
   module ErrorHandlers
-    class Sentry
-      include Logging
+    class Sentry < Base
 
       def initialize
         unless Raven.respond_to?(:capture_exception)

--- a/spec/hutch/cli_spec.rb
+++ b/spec/hutch/cli_spec.rb
@@ -4,6 +4,19 @@ require 'tempfile'
 describe Hutch::CLI do
   let(:cli) { Hutch::CLI.new }
 
+  describe "#start_work_loop" do
+    context "connection error during setup" do
+      let(:error) { Hutch::ConnectionError.new }
+      it "gets reported using error handlers" do
+        allow(Hutch).to receive(:connect).and_raise(error)
+        Hutch::Config[:error_handlers].each do |backend|
+          expect(backend).to receive(:handle_setup_exception).with(error)
+        end
+        cli.start_work_loop
+      end
+    end
+  end
+
   describe "#parse_options" do
     context "--config" do
       context "when the config file does not exist" do

--- a/spec/hutch/error_handlers/airbrake_spec.rb
+++ b/spec/hutch/error_handlers/airbrake_spec.rb
@@ -27,4 +27,23 @@ describe Hutch::ErrorHandlers::Airbrake do
       error_handler.handle(properties, payload, consumer, ex)
     end
   end
+
+  describe '#handle_setup_exception' do
+    let(:error) do
+      begin
+        raise "Stuff went wrong"
+      rescue RuntimeError => err
+        err
+      end
+    end
+
+    it "logs the error to Airbrake" do
+      ex = error
+      message = {
+        cgi_data: ENV.to_hash,
+      }
+      expect(::Airbrake).to receive(:notify).with(ex, message)
+      error_handler.handle_setup_exception(ex)
+    end
+  end
 end

--- a/spec/hutch/error_handlers/honeybadger_spec.rb
+++ b/spec/hutch/error_handlers/honeybadger_spec.rb
@@ -34,4 +34,25 @@ describe Hutch::ErrorHandlers::Honeybadger do
       error_handler.handle(properties, payload, consumer, ex)
     end
   end
+
+  describe '#handle_setup_exception' do
+    let(:error) do
+      begin
+        raise "Stuff went wrong during setup"
+      rescue RuntimeError => err
+        err
+      end
+    end
+
+    it "logs the error to Honeybadger" do
+      ex = error
+      message = {
+        :error_class => ex.class.name,
+          :error_message => "#{ ex.class.name }: #{ ex.message }",
+          :backtrace => ex.backtrace,
+      }
+      expect(error_handler).to receive(:notify_honeybadger).with(message)
+      error_handler.handle_setup_exception(ex)
+    end
+  end
 end

--- a/spec/hutch/error_handlers/logger_spec.rb
+++ b/spec/hutch/error_handlers/logger_spec.rb
@@ -14,4 +14,15 @@ describe Hutch::ErrorHandlers::Logger do
       error_handler.handle(properties, payload, double, error)
     end
   end
+
+  describe '#handle_setup_exception' do
+    let(:error) { double(message: "Stuff went wrong during setup",
+                       class: "RuntimeError",
+                       backtrace: ["line 1", "line 2"]) }
+
+    it "logs two separate lines" do
+      expect(Hutch::Logging.logger).to receive(:error).exactly(2).times
+      error_handler.handle_setup_exception(error)
+    end
+  end
 end

--- a/spec/hutch/error_handlers/opbeat_spec.rb
+++ b/spec/hutch/error_handlers/opbeat_spec.rb
@@ -19,4 +19,19 @@ describe Hutch::ErrorHandlers::Opbeat do
       error_handler.handle(properties, payload, double, error)
     end
   end
+
+  describe '#handle_setup_exception' do
+    let(:error) do
+      begin
+        raise "Stuff went wrong during setup"
+      rescue RuntimeError => err
+        err
+      end
+    end
+
+    it "logs the error to Opbeat" do
+      expect(Opbeat).to receive(:report).with(error)
+      error_handler.handle_setup_exception(error)
+    end
+  end
 end

--- a/spec/hutch/error_handlers/sentry_spec.rb
+++ b/spec/hutch/error_handlers/sentry_spec.rb
@@ -19,4 +19,19 @@ describe Hutch::ErrorHandlers::Sentry do
       error_handler.handle(properties, payload, double, error)
     end
   end
+
+  describe '#handle_setup_exception' do
+    let(:error) do
+      begin
+        raise "Stuff went wrong during setup"
+      rescue RuntimeError => err
+        err
+      end
+    end
+
+    it "logs the error to Sentry" do
+      expect(Raven).to receive(:capture_exception).with(error)
+      error_handler.handle_setup_exception(error)
+    end
+  end
 end


### PR DESCRIPTION
To handle setup exceptions, a method was added to each error handler.

Said method is subsequently called when setup of the client fails.

This is to ensure that a failed setup is not only logged, but also
reported to e.g. sentry.

Furthermore, a base class indicating the interface for error handlers is added.

Closes #288