### PR TITLE
Travis: use latest jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rvm: 2.2.8
     - rvm: 2.1
     - rvm: 2.0
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.1.15.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS='--debug'


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html