### PR TITLE
When using the uri config option: Respect amqps specification and use default protocol ports if unspecified

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -292,11 +292,16 @@ module Hutch
 
       u = URI.parse(@config[:uri])
 
+      @config[:mq_tls]      = u.scheme == 'amqps'
       @config[:mq_host]     = u.host
-      @config[:mq_port]     = u.port
+      @config[:mq_port]     = u.port || default_mq_port
       @config[:mq_vhost]    = u.path.sub(/^\//, "")
       @config[:mq_username] = u.user
       @config[:mq_password] = u.password
+    end
+
+    def default_mq_port
+      @config[:mq_tls] ? AMQ::Protocol::TLS_PORT : AMQ::Protocol::DEFAULT_PORT
     end
 
     def sanitized_uri

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -92,6 +92,36 @@ describe Hutch::Broker do
 
       connection.close
     end
+
+    context 'when configured with a URI' do
+      context 'which specifies the port' do
+        before { config[:uri] = 'amqp://guest:guest@127.0.0.1:5672/' }
+
+        it 'successfully connects' do
+          expect { broker.open_connection }.not_to raise_error
+        end
+      end
+
+      context 'which does not specify port and uses the amqp scheme' do
+        before { config[:uri] = 'amqp://guest:guest@127.0.0.1/' }
+
+        it 'successfully connects' do
+          expect { broker.open_connection }.not_to raise_error
+        end
+      end
+
+      context 'which specifies the amqps scheme' do
+        before { config[:uri] = 'amqps://guest:guest@127.0.0.1/' }
+
+        it 'utilises TLS' do
+          expect(Hutch::Adapter).to receive(:new).with(
+            hash_including(tls: true, port: 5671)
+          ).and_return(instance_double('Hutch::Adapter', start: nil))
+
+          broker.open_connection
+        end
+      end
+    end
   end
 
   describe '#open_connection!' do


### PR DESCRIPTION
### What does this PR do?

Restores functionality implemented in https://github.com/gocardless/hutch/pull/159 and since lost to:

* Respect `amqps` specification when using the URI config option (ie. utilise TLS)
* Default to the standard protocol ports when not specified and using the URI config option (5671 for TLS, 5672 otherwise)

This means that:

`amqp://guest:guest@127.0.0.1/` connects to the server on port 5672 and does not utilise TLS.
`amqps://guest:guest@127.0.0.1/` connects to the server on port 5671 and does utilise TLS.

It also adds test cases for this functionality to prevent another regression.

### Where should the reviewer start?

Changes are all within `Hutch::Broker#parse_uri`

### Any background context you want to provide?

Background context can be found in the original issue ://github.com/gocardless/hutch/issues/304

### Any specific implementation details?

The test for covering when amqps scheme is utilised has to stub out `Hutch::Adapter` instead of acting like an integration test in a similar manner to the surrounding specs because it appears a default rabbitmq install does not activate TLS listeners and as such a user who was to run the test suite without changing their rabbitmq server config would get failing specs if the adapter was not stubbed.

\cc @michaelklishin 