### PR TITLE
Ensure that connecting method is synchronized

### DIFF
--- a/lib/hutch.rb
+++ b/lib/hutch.rb
@@ -14,6 +14,8 @@ require 'hutch/exceptions'
 require 'hutch/tracers'
 
 module Hutch
+  @@mutex = Mutex.new
+
   def self.register_consumer(consumer)
     self.consumers << consumer
   end
@@ -40,10 +42,12 @@ module Hutch
   # @param config [Hash] Configuration
   # @option options [Boolean] :enable_http_api_use
   def self.connect(options = {}, config = Hutch::Config)
-    return if connected?
-
-    @broker = Hutch::Broker.new(config)
-    @broker.connect(options)
+    @@mutex.synchronize do
+      unless connected?
+        @broker = Hutch::Broker.new(config)
+        @broker.connect(options)
+      end
+    end
   end
 
   def self.disconnect


### PR DESCRIPTION
When there are competing publisher threads, there is a chance that the
publisher has not been initialized when Hutch is registered as
connected.  This happens when connections are lazily created vs at application load (for example).
The following diagram should shed some light on the race condition:

```
        Thread 1                  Hutch                   Thread 2
        --------                  -------                 ---------
t1      Hutch.publish()  --->  connected? (FALSE)
                           |-> open_connection!
t2                             connected? (TRUE)  <--- Hutch.publish()
                               @broker.publish()   |-> NoMethodError (@publisher)
t3                         |-> declare_publisher!
        PUBLISHED        <-|   @broker.publish()
```

Wrapping the `Hutch.connect` call should resolve this issue.