### PR TITLE
Travis: jruby-9.1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - rvm: 2.4.2
     - rvm: 2.3.5
     - rvm: 2.2.8
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS='--debug'


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/04/23/jruby-9-1-17-0.html