### PR TITLE
Fix NameError: undefined local variable or method `allowed_consumers`

### DIFF
--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -118,7 +118,7 @@ module Hutch
     def group_restricted?(consumer)
       consumers_to_load = consumer_groups[group]
       if consumers_to_load
-        !allowed_consumers.include?(consumer.name)
+        !consumers_to_load.include?(consumer.name)
       else
         true
       end


### PR DESCRIPTION
It seems during rename(https://github.com/gocardless/hutch/commit/d509c19763902e6ebf07a57d78a24431f254015c#diff-16eb6365e2d1f19f4df2b8aba16e4f9cL121) took place a mistake.