### PR TITLE
CI: update matrix - new JRuby out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ before_script:
   - until sudo lsof -i:5672; do echo "Waiting for RabbitMQ to start..."; sleep 1; done
 matrix:
   include:
-    - rvm: "2.6.0"
-    - rvm: "2.5.1"
-    - rvm: "2.4.2"
-    - rvm: "2.3.5"
-    - rvm: "jruby-9.2.5.0"
+    - rvm: "2.6.1"
+    - rvm: "2.5.3"
+    - rvm: "2.4.5"
+    - rvm: "2.3.8"
+    - rvm: "jruby-9.2.6.0"
     - rvm: "ruby-head"
   allow_failures:
     rvm:
-      - "jruby-9.2.5.0"
+      - "jruby-9.2.6.0"
       - ruby-head
 
 services:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)