### PR TITLE
CI: Use 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_script:
   - until sudo lsof -i:5672; do echo "Waiting for RabbitMQ to start..."; sleep 1; done
 matrix:
   include:
-    - rvm: "2.6.1"
-    - rvm: "2.5.3"
+    - rvm: "2.6.2"
+    - rvm: "2.5.5"
     - rvm: "2.4.5"
     - rvm: "2.3.8"
     - rvm: "jruby-9.2.6.0"


### PR DESCRIPTION
This PR updates the CI matrix to the latest release.