### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,10 @@ matrix:
       - "jruby-9.2.9.0"
       - ruby-head
 
+addons:
+  apt:
+    packages:
+    - rabbitmq-server 
+
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
     - rvm: "2.5.6"
     - rvm: "2.4.7"
     - rvm: "2.3.8"
-    - rvm: "jruby-9.2.8.0"
+    - rvm: "jruby-9.2.9.0"
     - rvm: "ruby-head"
   allow_failures:
     rvm:
-      - "jruby-9.2.8.0"
+      - "jruby-9.2.9.0"
       - ruby-head
 
 services:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.9.0**.

[JRuby 9.2.9.0 release blog post](https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html)