### PR TITLE
Better log levels in the message publisher

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -184,7 +184,7 @@ module Hutch
 
       filtered = api_client.bindings.
         reject { |b| b['destination'] == b['routing_key'] }.
-        filter { |b| b['source'] == @config[:mq_exchange] && b['vhost'] == @config[:mq_vhost] }
+        select { |b| b['source'] == @config[:mq_exchange] && b['vhost'] == @config[:mq_vhost] }
 
       filtered.each do |binding|
         results[binding['destination']] << binding['routing_key']
@@ -197,7 +197,7 @@ module Hutch
     def unbind_redundant_bindings(queue, routing_keys)
       return unless http_api_use_enabled?
 
-      filtered = bindings.filter { |dest, keys| dest == queue.name }
+      filtered = bindings.select { |dest, keys| dest == queue.name }
       filtered.each do |dest, keys|
         keys.reject { |key| routing_keys.include?(key) }.each do |key|
           logger.debug "removing redundant binding #{queue.name} <--> #{key}"

--- a/lib/hutch/publisher.rb
+++ b/lib/hutch/publisher.rb
@@ -42,7 +42,7 @@ module Hutch
     private
 
     def log_publication(serializer, payload, routing_key)
-      logger.info {
+      logger.debug {
         spec =
           if serializer.binary?
             "#{payload.bytesize} bytes message"


### PR DESCRIPTION
Having the entire payload logged at the "INFO" level is not ideal due to
the following reasons:
- PII data might be contained there and there is no way to fitler it out
- Payload might be big enough that logging aggregators might struggle with
the sheer amount of data
- Since the log level is shared by reusing the rails/sinatra logger, INFO level
might be too verbose for hutch but WARN level not verbose enough for the other.

While initially I considered implementing a feature to allow for filtering
the payload for PII or triming the output, a quick solution to all problems
listed above is to split the logging into two, the INFO level handing the
generic part of the log, with the message ID injected for easy tracking
and in case the payload is needed, log level can be set to DEBUG, which
should only be needed in development/testing environments.