### PR TITLE
Make RabbitMQ exchange type configurable

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -122,11 +122,12 @@ module Hutch
 
     def declare_exchange(ch = channel)
       exchange_name = @config[:mq_exchange]
+      exchange_type = @config[:mq_exchange_type]
       exchange_options = { durable: true }.merge(@config[:mq_exchange_options])
       logger.info "using topic exchange '#{exchange_name}'"
 
       with_bunny_precondition_handler('exchange') do
-        ch.topic(exchange_name, exchange_options)
+        Bunny::Exchange.new(ch, exchange_type, exchange_name, exchange_options)
       end
     end
 

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -49,6 +49,9 @@ module Hutch
     # RabbitMQ Exchange to use for publishing
     string_setting :mq_exchange, 'hutch'
 
+    # RabbitMQ Exchange type to use for publishing
+    string_setting :mq_exchange_type, 'topic'
+
     # RabbitMQ vhost to use
     string_setting :mq_vhost, '/'
 


### PR DESCRIPTION
This changes makes the exchange type configurable with a default to use a topic exchange. 
This is done simply by declaring the exchange through a different Bunny API:
not using the `channel.topic()` shortcut but initializing a new `Bunny::Exchange.new()` 

Though Hutch is opinionated on the exchange/message types used. (which is good!) this makes it possible to for example use Hutch in combination with the [delayed message exchange RabbitMQ plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) which defines a new exchange type but can act like a topic exchange.

Example usage:

```
Hutch::Config.set(:mq_exchange_type, 'x-delayed-message')
Hutch::Config.set(:mq_exchange_options, { arguments: { 'x-delayed-type': 'topic' } })
```

I don't know much about RabbitMQ internals and the internals of the RabbitMQ plugins but considering this minor change I thought it is worth to consider it? 